### PR TITLE
OP - FEATURE: All users should not see "Apply to be a rider" if they are a rider #9

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (
+                hasRole(currentUser, "ROLE_MEMBER") && !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/config/SecurityConfig.java
@@ -90,6 +90,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
           }
 
+          if (getRider(email)) {
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
+          }
+
           if (email.endsWith("@ucsb.edu")) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
           }
@@ -112,6 +116,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   public boolean getDriver(String email){
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getDriver();
+  }
+
+  public boolean getRider(String email){
+    Optional<User> u = userRepository.findByEmail(email);
+    return u.isPresent() && u.get().getRider();
   }
   
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -48,13 +48,17 @@ public class RoleInterceptor implements HandlerInterceptor {
                 Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
                 Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
                         grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
-                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER"))
+                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER")
+                                && !grantedAuth.getAuthority().equals("ROLE_RIDER"))
                         .collect(Collectors.toSet());
                 if (user.getAdmin()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 }
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
+                }
+                if (user.getRider()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
                 }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));


### PR DESCRIPTION
Made is so that only users with the role "ROLE_MEMBER" and not "ROLE_RIDER" can see the "Apply to be a rider" in the Navbar. Fixed a bug in which "ROLE_RIDER" was not being changed and updated properly when changing it in the "Admin" menu.  Unable to provide Dokku link because disk quota exceeded.

When assigned "ROLE_RIDER":
<img width="1335" alt="Screenshot 2024-02-27 at 6 08 36 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/61f6c019-58ae-4a1f-ae35-2d7601360985">

When not assigned "ROLE_RIDER" (and assigned "ROLE_MEMBER"):
<img width="1316" alt="Screenshot 2024-02-27 at 6 08 47 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/6c9511a1-8dff-48df-ba72-050fe6791bd6">


Closes #9 