### PR TITLE
OP - FEATURE: All users should not see "Apply to be a rider" if they are a rider #9

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (
+                hasRole(currentUser, "ROLE_MEMBER") && !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,8 +115,8 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && !hasRole(currentUser, "ROLE_RIDER") && (
-                  <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
+                !hasRole(currentUser, "ROLE_RIDER") && (
+                  <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }
 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -670,11 +670,24 @@ describe("AppNavbar tests", () => {
         
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
         const driverLink = screen.queryByTestId("appnavbar-driver-link");
-        expect(driverLink).not.toBeInTheDocument();      
+        expect(driverLink).not.toBeInTheDocument();          
+    });
+
+    test("Apply to be a rider should not appear for rider users", async () => {
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
         
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
-        const applyMenu = screen.queryByText("Apply to be a Rider");
-        expect(applyMenu).not.toBeInTheDocument();      
+        const applyLink = screen.queryByTestId("appnavbar-applytoberider");
+        expect(applyLink).not.toBeInTheDocument();
     });
 
 });

--- a/src/main/java/edu/ucsb/cs156/gauchoride/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/config/SecurityConfig.java
@@ -90,6 +90,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
           }
 
+          if (getRider(email)) {
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
+          }
+
           if (email.endsWith("@ucsb.edu")) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
           }
@@ -112,6 +116,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   public boolean getDriver(String email){
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getDriver();
+  }
+
+  public boolean getRider(String email){
+    Optional<User> u = userRepository.findByEmail(email);
+    return u.isPresent() && u.get().getRider();
   }
   
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -48,13 +48,17 @@ public class RoleInterceptor implements HandlerInterceptor {
                 Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
                 Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
                         grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
-                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER"))
+                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER")
+                                && !grantedAuth.getAuthority().equals("ROLE_RIDER"))
                         .collect(Collectors.toSet());
                 if (user.getAdmin()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 }
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
+                }
+                if (user.getRider()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
                 }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));


### PR DESCRIPTION
Made is so that all users that don't have "ROLE_RIDER" can see the "Apply to be a rider" in the Navbar. Fixed a bug in which "ROLE_RIDER" was not being changed and updated properly when changing it in the "Admin" menu. Unable to provide Dokku link because disk quota exceeded.

When assigned "ROLE_RIDER":
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/91a6bf4e-9709-4a8a-b60f-e5f9ffec351b)

When not assigned "ROLE_RIDER":
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/8e5b9b43-8018-4db5-bf72-9422e09ba286)

Closes #9 