### PR TITLE
OP - FEATURE: All users should not see "Apply to be a rider" if they are a rider #9 

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (
+                hasRole(currentUser, "ROLE_MEMBER") && !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,8 +115,8 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && !hasRole(currentUser, "ROLE_RIDER") && (
-                  <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
+                !hasRole(currentUser, "ROLE_RIDER") && (
+                  <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }
 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -670,11 +670,24 @@ describe("AppNavbar tests", () => {
         
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
         const driverLink = screen.queryByTestId("appnavbar-driver-link");
-        expect(driverLink).not.toBeInTheDocument();      
+        expect(driverLink).not.toBeInTheDocument();          
+    });
+
+    test("Apply to be a rider should not appear for rider users", async () => {
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
         
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
-        const applyMenu = screen.queryByText("Apply to be a Rider");
-        expect(applyMenu).not.toBeInTheDocument();      
+        const applyLink = screen.queryByTestId("appnavbar-applytoberider");
+        expect(applyLink).not.toBeInTheDocument();
     });
 
 });

--- a/src/main/java/edu/ucsb/cs156/gauchoride/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/config/SecurityConfig.java
@@ -90,6 +90,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
           }
 
+          if (getRider(email)) {
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
+          }
+
           if (email.endsWith("@ucsb.edu")) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
           }
@@ -112,6 +116,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   public boolean getDriver(String email){
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getDriver();
+  }
+
+  public boolean getRider(String email){
+    Optional<User> u = userRepository.findByEmail(email);
+    return u.isPresent() && u.get().getRider();
   }
   
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -48,13 +48,17 @@ public class RoleInterceptor implements HandlerInterceptor {
                 Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
                 Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
                         grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
-                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER"))
+                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER")
+                                && !grantedAuth.getAuthority().equals("ROLE_RIDER"))
                         .collect(Collectors.toSet());
                 if (user.getAdmin()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 }
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
+                }
+                if (user.getRider()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
                 }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));

--- a/src/test/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptorTests.java
@@ -1,40 +1,40 @@
 package edu.ucsb.cs156.gauchoride.interceptors;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import edu.ucsb.cs156.gauchoride.entities.User;
+
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.mock.web.MockHttpServletResponse;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.HashSet;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
-
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -62,6 +62,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                 Set<GrantedAuthority> authorities = new HashSet<>();
                 authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 authorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
+                authorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
                 authorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
 
                 OAuth2User user = new DefaultOAuth2User(authorities, attributes, "name");
@@ -94,6 +95,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .id(15L)
                                 .admin(false)
                                 .driver(true)
+                                .rider(true)
                                 .build();
                 when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
 
@@ -120,10 +122,13 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
                 boolean role_driver = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
                 assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
                 assertTrue(role_driver, "ROLE_DRIVER should be in roles list");
+                assertTrue(role_rider, "ROLE_RIDER should be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 
@@ -160,10 +165,13 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
                 boolean role_driver = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
                 assertTrue(role_admin, "ROLE_ADMIN should not be in roles list");
                 assertFalse(role_driver, "ROLE_DRIVER should be in roles list");
+                assertFalse(role_rider, "ROLE_RIDER should be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 
@@ -200,10 +208,13 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
                 boolean role_driver = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
                 assertTrue(role_admin, "ROLE_ADMIN should not be in roles list");
                 assertTrue(role_driver, "ROLE_DRIVER should be in roles list");
+                assertTrue(role_rider, "ROLE_RIDER should be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 }


### PR DESCRIPTION
Made is so that all users that don't have "ROLE_RIDER" can see the "Apply to be a rider" in the Navbar. Added test cases to AppNavbar.test in order to test the new changes. In order for the feature to work properly, I fixed a bug in which "ROLE_RIDER" was not being changed and updated properly when changing it in the "Admin" menu. This was done through the SecurityConfig and RoleInterceptor. Additionally, I added tests for to RoleInterceptorTests for the features added in the fix. Unable to provide Dokku link because disk quota exceeded.


When assigned "ROLE_RIDER":
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/8ecf7f6b-edde-41e1-8dfb-96df1a036e2a)


When not assigned "ROLE_RIDER":
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/75485b04-bf99-4128-bf4d-34d61fb8712e)


Closes #9 
