### PR TITLE
OP - FEATURE: Change confusing ride request field names #94

### DIFF
--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Form } from 'react-bootstrap';
+import { Button, Form, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
 
@@ -66,7 +66,12 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="start">Start Time</Form.Label>
+                <Form.Label htmlFor="start">Pick Up Time</Form.Label>
+                <OverlayTrigger
+                    placement="top"
+                    overlay={<Tooltip>This is when you would like to picked up.</Tooltip>}
+                    delay='100'
+                >
                 <Form.Control
                     data-testid={testIdPrefix + "-start"}
                     id="start"
@@ -83,13 +88,19 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     defaultValue={initialContents?.startTime}
 
                 />
+                </OverlayTrigger>
                 <Form.Control.Feedback type="invalid">
                     {errors.start?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="end">End Time</Form.Label>
+                <Form.Label htmlFor="end">Drop Off Time</Form.Label>
+                <OverlayTrigger
+                    placement="top"
+                    overlay={<Tooltip>This is the latest that you would like to arrive by.</Tooltip>}
+                    delay='100'
+                >
                 <Form.Control
                     data-testid={testIdPrefix + "-end"}
                     id="end"
@@ -105,6 +116,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"   
                     defaultValue={initialContents?.endTime}     
                 />
+                </OverlayTrigger>
                 <Form.Control.Feedback type="invalid">
                     {errors.end?.message}
                 </Form.Control.Feedback>

--- a/frontend/src/main/components/Ride/RideTable.js
+++ b/frontend/src/main/components/Ride/RideTable.js
@@ -51,12 +51,12 @@ export default function RideTable({
             accessor: 'course',
         },
         {
-            Header: 'Start Time',
-            accessor: 'startTime',
+            Header: 'Pick Up Time',
+            accessor: 'pickUpTime',
         },
         {
-            Header: 'End Time',
-            accessor: 'endTime',
+            Header: 'Drop Off Time',
+            accessor: 'dropOffTime',
         },
         {
             Header: 'Pick Up Building',
@@ -98,12 +98,12 @@ export default function RideTable({
             accessor: 'course',
         },
         {
-            Header: 'Start Time',
-            accessor: 'startTime',
+            Header: 'Pick Up Time',
+            accessor: 'pickUpTime',
         },
         {
-            Header: 'End Time',
-            accessor: 'endTime',
+            Header: 'Drop Off Time',
+            accessor: 'dropOffTime',
         },
         {
             Header: 'Pick Up Building',
@@ -145,12 +145,12 @@ export default function RideTable({
             accessor: 'course',
         },
         {
-            Header: 'Start Time',
-            accessor: 'startTime',
+            Header: 'Pick Up Time',
+            accessor: 'pickUpTime',
         },
         {
-            Header: 'End Time',
-            accessor: 'endTime',
+            Header: 'Drop Off Time',
+            accessor: 'dropOffTime',
         },
         {
             Header: 'Pick Up Building',

--- a/frontend/src/tests/components/Ride/RideForm.test.js
+++ b/frontend/src/tests/components/Ride/RideForm.test.js
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("RideForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["Day of Week", "Start Time", "End Time", "Pick Up Building", "Drop Off Building", "Room Number for Dropoff", "Course Number"];
+    const expectedHeaders = ["Day of Week", "Pick Up Time", "Drop Off Time", "Pick Up Building", "Drop Off Building", "Room Number for Dropoff", "Course Number"];
     const testId = "RideForm";
 
     test("renders correctly with no initialContents", async () => {

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -91,8 +91,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Student','Driver', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'student', 'driver', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Student','Driver', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'student', 'driver', 'course', 'pickUpTime', 'dropOffTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -133,8 +133,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Driver', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day',  'driver', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Driver', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day',  'driver', 'course', 'pickUpTime', 'dropOffTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -173,8 +173,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Student', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'student', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Student', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'student', 'course', 'pickUpTime', 'dropOffTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {


### PR DESCRIPTION
Changed "Start Time" to "Pick Up Time" and "End Time" to "Drop Off Time" in RideForm and RideTable. Additionally, added a feature in which hovering over the changed fields in the form will display a description of the field in order to help users accurately fill out the form. All tests update for changed and additional features.


New field names:
<img width="1365" alt="Screenshot 2024-02-28 at 8 55 40 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/2ee1aaa7-ade4-482e-af6b-4eac5f23fb25">

<img width="1345" alt="Screenshot 2024-02-28 at 8 55 49 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/adb09eae-813c-447d-b56f-331b15eefa88">


Description when hovering:
<img width="1367" alt="Screenshot 2024-02-28 at 8 55 57 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/5049c80e-4260-4d75-9e83-f30624006e2b">

<img width="1331" alt="Screenshot 2024-02-28 at 8 56 08 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/96025896/cb06ffce-64d5-4ebe-b97d-d40f311b1a31">


Closes #30 