### PR TITLE
Added the RiderApplicationShowPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,6 +22,7 @@ import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
+import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -55,7 +56,7 @@ function App() {
           (hasRole(currentUser, "ROLE_RIDER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/ride/create" element={<RideRequestCreatePage />} />
         }
         {
-          (hasRole(currentUser, "ROLE_MEMBER") )&& <Route exact path="/apply/rider/show/:id" element={<RiderApplicationEditPageMember />} />
+          (hasRole(currentUser, "ROLE_MEMBER") )&& <Route exact path="/apply/rider/show/:id" element={<RiderApplicationShowPageMember />} />
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_RIDER")) && <Route exact path="/ride/edit/:id" element={<RideRequestEditPage />} />
@@ -89,9 +90,6 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/new" element={<RiderApplicationCreatePage />} />
-        }
-        {
-          (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/show/:id" element={<RiderApplicationEditPageMember />} />
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageMember />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,23 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import HomePage from "main/pages/HomePage";
-import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
-import PageNotFound from "main/pages/PageNotFound";
 import DriverListPage from "main/pages/DriverListPage";
+import HomePage from "main/pages/HomePage";
+import PageNotFound from "main/pages/PageNotFound";
+import ProfilePage from "main/pages/ProfilePage";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
+import ChatPage from "main/pages/ChatPage";
 import RideRequestCreatePage from "main/pages/Ride/RideRequestCreatePage";
 import RideRequestEditPage from "main/pages/Ride/RideRequestEditPage";
 import RideRequestIndexPage from "main/pages/Ride/RideRequestIndexPage";
 import ShiftPage from "main/pages/ShiftPage";
-import ChatPage from "main/pages/ChatPage";
 
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
 import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
 import ShiftIndexPage from "main/pages/Shift/ShiftIndexPage";
 
+import DriverInfoPage from "main/pages/DriverInfoPage";
 import DriverPage from "main/pages/DriverPage";
 import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
-import DriverInfoPage from "main/pages/DriverInfoPage";
 
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
@@ -84,6 +84,7 @@ function App() {
         {
           (hasRole(currentUser, "ROLE_DRIVER") ) && <Route exact path="/drivershifts" element={<DriverDashboardPage />} />
         }
+        {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider" element={<RiderApplicationIndexPageMember />} />
         }
         {

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -1,0 +1,134 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+function RiderApplicationShowForm({ initialContents,  buttonLabel = "Apply", email}) {
+    const navigate = useNavigate();
+    
+    // Stryker disable all
+    const {
+        register,
+    } = useForm(
+        { defaultValues: initialContents }
+    );
+    // Stryker enable all
+   
+    const testIdPrefix = "RiderApplicationShowForm";
+
+
+    return (
+
+        <Form>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="status">Status</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-status"}
+                        id="status"
+                        type="text"
+                        {...register("status")}
+                        defaultValue={initialContents?.status}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="email">Email</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-email"}
+                    id="email"
+                    type="text"
+                    {...register("email")}
+                    defaultValue={email}
+                    disabled
+                />
+            </Form.Group>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="created_date">Date Applied</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-created_date"}
+                        id="created_date"
+                        type="text"
+                        {...register("created_date")}
+                        defaultValue={initialContents?.created_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-cancelled_date"}
+                        id="cancelled_date"
+                        type="text"
+                        {...register("cancelled_date")}
+                        defaultValue={initialContents?.cancelled_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-perm_number"}
+                        id="perm_number"
+                        type="text"
+                        {...register("perm_number")}
+                        defaultValue={initialContents?.perm_number}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="description">Description</Form.Label>
+                    <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-description"}
+                        id="description"
+                        as="textarea"
+                        {...register("description")}
+                        defaultValue={initialContents?.description}
+                        style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Button
+                type="submit"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                {buttonLabel}
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default RiderApplicationShowForm;

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationShowPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationShowPageMember.js
@@ -1,0 +1,65 @@
+import RiderApplicationShowForm from "main/components/RiderApplication/RiderApplicationShowForm";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { Navigate, useParams } from "react-router-dom";
+
+import { toast } from "react-toastify";
+
+export default function RiderApplicationShowPage() {
+  let { id } = useParams();
+
+  const { data: riderApplication, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/riderApplication?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/riderApplication`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (riderApplication) => ({
+    url: "/api/riderApplication",
+    method: "PUT",
+    params: {
+      id: riderApplication.id,
+    },
+    data: {
+        perm_number: riderApplication.perm_number,
+        description: riderApplication.description
+    }
+  });
+
+  const onSuccess = (riderApplication) => {
+    toast(`Application Updated - id: ${riderApplication.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/riderApplication?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+
+  if (isSuccess) {
+    return <Navigate to="/apply/rider" />
+  }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Show Rider Application</h1>
+                {riderApplication &&
+                <RiderApplicationShowForm initialContents={riderApplication} buttonLabel="Back" />
+                }
+            </div>
+        </BasicLayout>
+    )
+}


### PR DESCRIPTION
In this pull request, I added the RiderApplicationShowPage. Users can click "show" on the Rider Applications Table to view the details of any application on the page, but they cannot edit them.

The page contains Status, Email, Date Applied,Date Cancelled, Notes, Perm Number, Description

image:
<img width="1401" alt="Screenshot 2024-02-28 at 20 55 08" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/122643397/3c3eea01-4f4f-4aef-ab76-bfab1f242c6d">


[Close#31](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/issues/31)