### PR TITLE
Added the RiderApplicationShowPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,6 +22,7 @@ import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
+import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -55,7 +56,7 @@ function App() {
           (hasRole(currentUser, "ROLE_RIDER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/ride/create" element={<RideRequestCreatePage />} />
         }
         {
-          (hasRole(currentUser, "ROLE_MEMBER") )&& <Route exact path="/apply/rider/show/:id" element={<RiderApplicationEditPageMember />} />
+          (hasRole(currentUser, "ROLE_MEMBER") )&& <Route exact path="/apply/rider/show/:id" element={<RiderApplicationShowPageMember />} />
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_RIDER")) && <Route exact path="/ride/edit/:id" element={<RideRequestEditPage />} />
@@ -89,9 +90,6 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/new" element={<RiderApplicationCreatePage />} />
-        }
-        {
-          (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/show/:id" element={<RiderApplicationEditPageMember />} />
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageMember />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,23 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import HomePage from "main/pages/HomePage";
-import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
-import PageNotFound from "main/pages/PageNotFound";
 import DriverListPage from "main/pages/DriverListPage";
+import HomePage from "main/pages/HomePage";
+import PageNotFound from "main/pages/PageNotFound";
+import ProfilePage from "main/pages/ProfilePage";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
+import ChatPage from "main/pages/ChatPage";
 import RideRequestCreatePage from "main/pages/Ride/RideRequestCreatePage";
 import RideRequestEditPage from "main/pages/Ride/RideRequestEditPage";
 import RideRequestIndexPage from "main/pages/Ride/RideRequestIndexPage";
 import ShiftPage from "main/pages/ShiftPage";
-import ChatPage from "main/pages/ChatPage";
 
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
 import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
 import ShiftIndexPage from "main/pages/Shift/ShiftIndexPage";
 
+import DriverInfoPage from "main/pages/DriverInfoPage";
 import DriverPage from "main/pages/DriverPage";
 import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
-import DriverInfoPage from "main/pages/DriverInfoPage";
 
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
@@ -84,6 +84,7 @@ function App() {
         {
           (hasRole(currentUser, "ROLE_DRIVER") ) && <Route exact path="/drivershifts" element={<DriverDashboardPage />} />
         }
+        {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider" element={<RiderApplicationIndexPageMember />} />
         }
         {

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -1,0 +1,134 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+function RiderApplicationShowForm({ initialContents,  buttonLabel = "Apply", email}) {
+    const navigate = useNavigate();
+    
+    // Stryker disable all
+    const {
+        register,
+    } = useForm(
+        { defaultValues: initialContents }
+    );
+    // Stryker enable all
+   
+    const testIdPrefix = "RiderApplicationShowForm";
+
+
+    return (
+
+        <Form>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="status">Status</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-status"}
+                        id="status"
+                        type="text"
+                        {...register("status")}
+                        defaultValue={initialContents?.status}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="email">Email</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-email"}
+                    id="email"
+                    type="text"
+                    {...register("email")}
+                    defaultValue={email}
+                    disabled
+                />
+            </Form.Group>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="created_date">Date Applied</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-created_date"}
+                        id="created_date"
+                        type="text"
+                        {...register("created_date")}
+                        defaultValue={initialContents?.created_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-cancelled_date"}
+                        id="cancelled_date"
+                        type="text"
+                        {...register("cancelled_date")}
+                        defaultValue={initialContents?.cancelled_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-perm_number"}
+                        id="perm_number"
+                        type="text"
+                        {...register("perm_number")}
+                        defaultValue={initialContents?.perm_number}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="description">Description</Form.Label>
+                    <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-description"}
+                        id="description"
+                        as="textarea"
+                        {...register("description")}
+                        defaultValue={initialContents?.description}
+                        style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Button
+                type="submit"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                {buttonLabel}
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default RiderApplicationShowForm;

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -2,12 +2,14 @@ import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
-function RiderApplicationShowForm({ initialContents,  buttonLabel = "Apply", email}) {
+function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email}) {
     const navigate = useNavigate();
     
     // Stryker disable all
     const {
         register,
+        formState: { errors },
+        handleSubmit,
     } = useForm(
         { defaultValues: initialContents }
     );
@@ -18,7 +20,7 @@ function RiderApplicationShowForm({ initialContents,  buttonLabel = "Apply", ema
 
     return (
 
-        <Form>
+        <Form onSubmit={handleSubmit()}>
 
             {initialContents && (
                 <Form.Group className="mb-3" >
@@ -59,6 +61,20 @@ function RiderApplicationShowForm({ initialContents,  buttonLabel = "Apply", ema
                     />
                 </Form.Group>
             )}
+            
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="updated_date">Date Updated</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-updated_date"}
+                        id="updated_date"
+                        type="text"
+                        {...register("updated_date")}
+                        defaultValue={initialContents?.updated_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
 
             {initialContents && (
                 <Form.Group className="mb-3" >
@@ -88,42 +104,60 @@ function RiderApplicationShowForm({ initialContents,  buttonLabel = "Apply", ema
                 </Form.Group>
             )}
 
-            {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
-                    <Form.Control
-                        data-testid={testIdPrefix + "-perm_number"}
-                        id="perm_number"
-                        type="text"
-                        {...register("perm_number")}
-                        defaultValue={initialContents?.perm_number}
-                        disabled
-                    />
-                </Form.Group>
-            )}
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-perm_number"}
+                    id="perm_number"
+                    type="text"
+                    isInvalid={Boolean(errors.perm_number)}
+                    {...register("perm_number", {
+                        required: "Perm Number is required.",
+                        minLength: {
+                            value: 7,
+                            message: "Perm Number must be exactly 7 characters long."
+                        },
+                        maxLength: {
+                            value: 7,
+                            message: "Perm Number must be exactly 7 characters long."
+                        }
+                    })}
+                    placeholder="e.g. 0000000"
+                    defaultValue={initialContents?.perm_number}
+                    disabled
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.perm_number?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
 
-            {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="description">Description</Form.Label>
-                    <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>
-                    <Form.Control
-                        data-testid={testIdPrefix + "-description"}
-                        id="description"
-                        as="textarea"
-                        {...register("description")}
-                        defaultValue={initialContents?.description}
-                        style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
-                        disabled
-                    />
-                </Form.Group>
-            )}
-
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="description">Description</Form.Label>
+                <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>                        
+                <Form.Control
+                    data-testid={testIdPrefix + "-description"}
+                    id="description"
+           horide   as="textarea"
+                    isInvalid={Boolean(errors.description)}
+                    {...register("description", {
+                        required: "Description is required."
+                    })}
+                    placeholder="e.g. My legs are broken."  
+                    defaultValue={initialContents?.description}
+                    disabled
+                    style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.description?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+            
             <Button
                 type="submit"
                 onClick={() => navigate(-1)}
                 data-testid={testIdPrefix + "-cancel"}
             >
-                {buttonLabel}
+            {buttonLabel}
             </Button>
 
         </Form>

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationShowPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationShowPageMember.js
@@ -1,9 +1,8 @@
 import RiderApplicationShowForm from "main/components/RiderApplication/RiderApplicationShowForm";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
-import { Navigate, useParams } from "react-router-dom";
+import { useBackend } from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
 
-import { toast } from "react-toastify";
 
 export default function RiderApplicationShowPage() {
   let { id } = useParams();
@@ -21,43 +20,12 @@ export default function RiderApplicationShowPage() {
       }
     );
 
-
-  const objectToAxiosPutParams = (riderApplication) => ({
-    url: "/api/riderApplication",
-    method: "PUT",
-    params: {
-      id: riderApplication.id,
-    },
-    data: {
-        perm_number: riderApplication.perm_number,
-        description: riderApplication.description
-    }
-  });
-
-  const onSuccess = (riderApplication) => {
-    toast(`Application Updated - id: ${riderApplication.id}`);
-  }
-
-  const mutation = useBackendMutation(
-    objectToAxiosPutParams,
-    { onSuccess },
-    // Stryker disable next-line all : hard to set up test for caching
-    [`/api/riderApplication?id=${id}`]
-  );
-
-  const { isSuccess } = mutation
-
-
-  if (isSuccess) {
-    return <Navigate to="/apply/rider" />
-  }
-
     return (
         <BasicLayout>
             <div className="pt-2">
                 <h1>Show Rider Application</h1>
                 {riderApplication &&
-                <RiderApplicationShowForm initialContents={riderApplication} buttonLabel="Back" />
+                <RiderApplicationShowForm initialContents={riderApplication}  buttonLabel="Back" />
                 }
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationShowPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationShowPageMember.js
@@ -1,0 +1,65 @@
+import RiderApplicationShowForm from "main/components/RiderApplication/RiderApplicationShowForm";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { Navigate, useParams } from "react-router-dom";
+
+import { toast } from "react-toastify";
+
+export default function RiderApplicationShowPage() {
+  let { id } = useParams();
+
+  const { data: riderApplication, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/riderApplication?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/riderApplication`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (riderApplication) => ({
+    url: "/api/riderApplication",
+    method: "PUT",
+    params: {
+      id: riderApplication.id,
+    },
+    data: {
+        perm_number: riderApplication.perm_number,
+        description: riderApplication.description
+    }
+  });
+
+  const onSuccess = (riderApplication) => {
+    toast(`Application Updated - id: ${riderApplication.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/riderApplication?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+
+  if (isSuccess) {
+    return <Navigate to="/apply/rider" />
+  }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Show Rider Application</h1>
+                {riderApplication &&
+                <RiderApplicationShowForm initialContents={riderApplication} buttonLabel="Back" />
+                }
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/stories/components/RiderApplication/RiderApplicationShowForm.stories.js
+++ b/frontend/src/stories/components/RiderApplication/RiderApplicationShowForm.stories.js
@@ -1,0 +1,30 @@
+import { riderApplicationFixtures } from 'fixtures/riderApplicationFixtures';
+import RiderApplicationShowForm from "main/components/RiderApplication/RiderApplicationShowForm";
+
+
+export default {
+    title: 'components/RiderApplication/RiderApplicationShowForm',
+    component: RiderApplicationShowForm
+};
+
+const Template = (args) => {
+    return (
+        <RiderApplicationShowForm {...args} />
+    )
+};
+
+
+export const Default = Template.bind({});
+
+Default.args = {
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+export const Show = Template.bind({});
+
+Show.args = {
+    intitialContents: riderApplicationFixtures.oneApplication,
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationShowForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationShowForm.test.js
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import { riderApplicationFixtures } from "fixtures/riderApplicationFixtures";
+import RiderApplicationShowForm from "main/components/RiderApplication/RiderApplicationShowForm";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("RiderApplicationShowForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Email", "Perm Number", "Description"];
+    const testId = "RiderApplicationShowForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationShowForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Back/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+          });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationShowForm initialContents={riderApplicationFixtures.oneRiderApplication} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Back/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationShowForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+});

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
@@ -1,12 +1,12 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
+import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
 
-import { apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import mockConsole from "jest-mock-console";
 

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPage.test.js
@@ -1,0 +1,134 @@
+import { render } from "@testing-library/react";
+import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import mockConsole from "jest-mock-console";
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("RiderApplicationShowPage tests", () => {
+
+    describe("when the backend doesn't return a todo", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.memberOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            const {queryByTestId, findByText} = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationShowPageMember />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await findByText("Show Rider Application");
+            expect(queryByTestId("RiderApplicationShowForm-status")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                perm_number: "1234567",
+                status: "pending",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                updated_date: "2023-04-17",
+                cancelled_date: "",
+                description: "",
+                notes: ""
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationShowPageMember />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationShowPageMember />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationShowForm-status");
+
+            const statusField =getByTestId("RiderApplicationShowForm-status");
+            const permNumberField = getByTestId("RiderApplicationShowForm-perm_number");
+            const emailField =getByTestId("RiderApplicationShowForm-email");
+            const createdDateField =getByTestId("RiderApplicationShowForm-created_date");
+            const updatedDateField =getByTestId("RiderApplicationShowForm-updated_date");
+            const cancelledDateField =getByTestId("RiderApplicationShowForm-cancelled_date");
+            const descriptionField = getByTestId("RiderApplicationShowForm-description");
+            const notesField =getByTestId("RiderApplicationShowForm-notes");
+
+            expect(statusField).toHaveValue("pending");
+            expect(permNumberField).toHaveValue("1234567");
+            expect(emailField).toHaveValue("random@example.org");
+            expect(createdDateField).toHaveValue("2023-04-17");
+            expect(updatedDateField).toHaveValue("2023-04-17");
+            expect(cancelledDateField).toHaveValue("");
+            expect(descriptionField).toHaveValue("");
+            expect(notesField).toHaveValue("");
+            
+        });
+
+       
+    });
+});


### PR DESCRIPTION
In this pull request, I added the RiderApplicationShowPage. Users can click "show" on the Rider Applications Table to view the details of any application on the page, but they cannot edit them.
[my PR link](https://proj-gauchoride-daoyi-dev.dokku-13.cs.ucsb.edu/apply/rider)

The page contains Status, Email, Date Applied,Date Cancelled, Notes, Perm Number, Description

After task 6 is completed, I will modify the page so that the displayed elements vary depending on the status.

image:
<img width="1356" alt="Screenshot 2024-02-29 at 18 08 08" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/122643397/2be68eca-e75c-4b89-84e5-462365c6f461">



[Close#31](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/issues/31)