### PR TITLE
ZP - Added Rider Application Tables for Admin's to review

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,10 +21,10 @@ import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
 
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
-import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
-import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
 import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
+import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -84,6 +84,7 @@ function App() {
         {
           (hasRole(currentUser, "ROLE_DRIVER") ) && <Route exact path="/drivershifts" element={<DriverDashboardPage />} />
         }
+        {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider" element={<RiderApplicationIndexPageMember />} />
         }
         {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,9 @@ import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
 
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
+import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
 import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
@@ -92,10 +94,10 @@ function App() {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/new" element={<RiderApplicationCreatePage />} />
         }
         {
-          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageMember />} />
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageAdmin />} />
         }
         {
-          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders/review/:id" element={<RiderApplicationEditPageMember />} />
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders/review/:id" element={<RiderApplicationEditPageAdmin />} />
         }
         {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/edit/:id" element={<RiderApplicationEditPageMember />} />

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -77,6 +77,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_ADMIN") && (
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item as={Link} to="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/admin/applications/riders">Rider Applications</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -1,0 +1,203 @@
+import React from 'react'
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Apply", email}) {
+    const navigate = useNavigate();
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents }
+    );
+    // Stryker enable all
+   
+    const testIdPrefix = "RiderApplicationForm";
+
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Application Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        defaultValue={initialContents?.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="userId">Applicant Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-userId"}
+                        id="userId"
+                        type="text"
+                        {...register("userId")}
+                        defaultValue={initialContents?.userId}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="status">Status</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-status"}
+                        id="status"
+                        type="text"
+                        {...register("status")}
+                        defaultValue={initialContents?.status}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="email">Email</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-email"}
+                    id="email"
+                    type="text"
+                    {...register("email")}
+                    defaultValue={email}
+                    disabled
+                />
+            </Form.Group>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="created_date">Date Applied</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-created_date"}
+                        id="created_date"
+                        type="text"
+                        {...register("created_date")}
+                        defaultValue={initialContents?.created_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+            
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="updated_date">Date Updated</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-updated_date"}
+                        id="updated_date"
+                        type="text"
+                        {...register("updated_date")}
+                        defaultValue={initialContents?.updated_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-cancelled_date"}
+                        id="cancelled_date"
+                        type="text"
+                        {...register("cancelled_date")}
+                        defaultValue={initialContents?.cancelled_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-perm_number"}
+                    id="perm_number"
+                    type="text"
+                    isInvalid={Boolean(errors.perm_number)}
+                    {...register("perm_number", {
+                        required: "Perm Number is required.",
+                        minLength: {
+                            value: 7,
+                            message: "Perm Number must be exactly 7 characters long."
+                        },
+                        maxLength: {
+                            value: 7,
+                            message: "Perm Number must be exactly 7 characters long."
+                        }
+                    })}
+                    placeholder="e.g. 0000000"
+                    defaultValue={initialContents?.perm_number}
+                    disabled
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.perm_number?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="description">Description</Form.Label>
+                <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>                        
+                <Form.Control
+                    data-testid={testIdPrefix + "-description"}
+                    id="description"
+                    as="textarea"
+                    isInvalid={Boolean(errors.description)}
+                    {...register("description", {
+                        required: "Description is required."
+                    })}
+                    placeholder="e.g. My legs are broken."  
+                    defaultValue={initialContents?.description}
+                    disabled
+                    style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.description?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default RiderApplicationForm;

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -3,7 +3,7 @@ import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
 
-function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Apply", email}) {
+function RiderApplicationEditForm({ initialContents, submitAction, email}) {
     const navigate = useNavigate();
     
     // Stryker disable all
@@ -16,12 +16,15 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
     );
     // Stryker enable all
    
-    const testIdPrefix = "RiderApplicationForm";
+    const testIdPrefix = "RiderApplicationEditForm";
 
-
+    const onSubmit = async (data) => {
+        submitAction(data);
+      };
+    
     return (
 
-        <Form onSubmit={handleSubmit(submitAction)}>
+        <Form onSubmit={handleSubmit(onSubmit)}>
 
             {initialContents && (
                 <Form.Group className="mb-3" >
@@ -119,45 +122,30 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
                 </Form.Group>
             )}
 
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="notes">Notes</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-notes"}
+                    id="notes"
+                    type="text"
+                    {...register("notes")}
+                    defaultValue={initialContents?.notes}
+                />
+            </Form.Group>
+
             {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                <Form.Group className="mb-3">
+                    <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
                     <Form.Control
-                        data-testid={testIdPrefix + "-notes"}
-                        id="notes"
+                        data-testid={testIdPrefix + "-perm_number"}
+                        id="perm_number"
                         type="text"
-                        {...register("notes")}
-                        defaultValue={initialContents?.notes}
+                        {...register("perm_number")}
+                        defaultValue={initialContents?.perm_number}
+                        disabled
                     />
                 </Form.Group>
             )}
-
-            <Form.Group className="mb-3">
-                <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-perm_number"}
-                    id="perm_number"
-                    type="text"
-                    isInvalid={Boolean(errors.perm_number)}
-                    {...register("perm_number", {
-                        required: "Perm Number is required.",
-                        minLength: {
-                            value: 7,
-                            message: "Perm Number must be exactly 7 characters long."
-                        },
-                        maxLength: {
-                            value: 7,
-                            message: "Perm Number must be exactly 7 characters long."
-                        }
-                    })}
-                    placeholder="e.g. 0000000"
-                    defaultValue={initialContents?.perm_number}
-                    disabled
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.perm_number?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="description">Description</Form.Label>
@@ -167,24 +155,18 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
                     id="description"
                     as="textarea"
                     isInvalid={Boolean(errors.description)}
-                    {...register("description", {
-                        required: "Description is required."
-                    })}
-                    placeholder="e.g. My legs are broken."  
+                    {...register("description")}
                     defaultValue={initialContents?.description}
                     disabled
                     style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
                 />
-                <Form.Control.Feedback type="invalid">
-                    {errors.description?.message}
-                </Form.Control.Feedback>
             </Form.Group>
 
             <Button
                 type="submit"
                 data-testid={testIdPrefix + "-submit"}
             >
-                {buttonLabel}
+                Save
             </Button>
             
             <Button
@@ -200,4 +182,4 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
     )
 }
 
-export default RiderApplicationForm;
+export default RiderApplicationEditForm;

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -30,6 +30,8 @@ export default function RiderApplicationEditPage() {
       id: riderApplication.id,
     },
     data: {
+        perm_number: riderApplication.perm_number,
+        description: riderApplication.description,
         notes: riderApplication.notes
     }
   });
@@ -52,7 +54,7 @@ export default function RiderApplicationEditPage() {
   }
 
   if (isSuccess) {
-    return <Navigate to="/apply/rider" />
+    return <Navigate to="/admin/applications/riders" />
   }
 
     return (
@@ -60,7 +62,7 @@ export default function RiderApplicationEditPage() {
             <div className="pt-2">
                 <h1>Edit Rider Application</h1>
                 {riderApplication &&
-                <RiderApplicationEditForm initialContents={riderApplication} submitAction={onSubmit} buttonLabel="Edit" />
+                <RiderApplicationEditForm initialContents={riderApplication} submitAction={onSubmit} />
                 }
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -1,0 +1,68 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import RiderApplicationEditForm from "main/components/RiderApplication/RiderApplicationEditForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+
+import { toast } from "react-toastify";
+
+export default function RiderApplicationEditPage() {
+  let { id } = useParams();
+
+  const { data: riderApplication, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/riderApplication?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/riderApplication`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (riderApplication) => ({
+    url: "/api/riderApplication",
+    method: "PUT",
+    params: {
+      id: riderApplication.id,
+    },
+    data: {
+        notes: riderApplication.notes
+    }
+  });
+
+  const onSuccess = (riderApplication) => {
+    toast(`Application Updated - id: ${riderApplication.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/riderApplication?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/apply/rider" />
+  }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit Rider Application</h1>
+                {riderApplication &&
+                <RiderApplicationEditForm initialContents={riderApplication} submitAction={onSubmit} buttonLabel="Edit" />
+                }
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
@@ -31,7 +31,8 @@ export default function RiderApplicationEditPage() {
     },
     data: {
         perm_number: riderApplication.perm_number,
-        description: riderApplication.description
+        description: riderApplication.description,
+        notes: riderApplication.notes
     }
   });
 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import {useCurrentUser} from 'main/utils/currentUser'
+import RiderApplicationTable from "main/components/RiderApplication/RiderApplicationTable";
+
+export default function RiderApplicationIndexPage() {
+
+    const currentUser = useCurrentUser();
+    // Stryker disable all
+    // Stryker restore all 
+    
+    const { data: riderApplications, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable all : hard to test for query caching
+            ["/api/rider"],
+            { method: "GET", url: "/api/rider" },
+            []
+            // Stryker restore all 
+    ); 
+    
+    const pendingRiderApplications = riderApplications?.filter(application => application.status === "pending");
+    
+    return (
+          <BasicLayout>
+              <div className="pt-2">
+                <h1>Pending Rider Applications</h1>
+                <RiderApplicationTable riderApplications={pendingRiderApplications} currentUser={currentUser} />
+                <h1>All Rider Applications</h1>
+                <RiderApplicationTable riderApplications={riderApplications} currentUser={currentUser} />
+              </div>
+          </BasicLayout>
+      );
+}

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import RiderApplicationEditForm from "main/components/RiderApplication/RiderApplicationEditForm";
+import { riderApplicationFixtures } from "fixtures/riderApplicationFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("RiderApplicationEditForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Email", "Notes", "Description"];
+    const testId = "RiderApplicationEditForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+          });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={riderApplicationFixtures.oneRiderApplication} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+});

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
@@ -191,6 +191,7 @@ describe("RiderApplicationEditPage tests", () => {
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
                 perm_number: "7654321",
                 description: "I broke my leg.",
+                notes: "",
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
@@ -1,0 +1,200 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("RiderApplicationEditPageAdmin tests", () => {
+
+    describe("when the backend doesn't return a todo", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.memberOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            const {queryByTestId, findByText} = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await findByText("Edit Rider Application");
+            expect(queryByTestId("RiderApplicationEditForm-id")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                perm_number: "1234567",
+                status: "pending",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                updated_date: "2023-04-17",
+                cancelled_date: "",
+                description: "",
+                notes: ""
+            });
+            axiosMock.onPut('/api/riderApplication').reply(200, {
+                id: 17,
+                perm_number: "7654321",
+                status: "pending",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                updated_date: "2023-08-25",
+                cancelled_date: "",
+                description: "My leg is broken",
+                notes: ""
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationEditForm-id");
+
+            const statusField =getByTestId("RiderApplicationEditForm-status");
+            const permNumberField = getByTestId("RiderApplicationEditForm-perm_number");
+            const emailField =getByTestId("RiderApplicationEditForm-email");
+            const createdDateField =getByTestId("RiderApplicationEditForm-created_date");
+            const updatedDateField =getByTestId("RiderApplicationEditForm-updated_date");
+            const cancelledDateField =getByTestId("RiderApplicationEditForm-cancelled_date");
+            const descriptionField = getByTestId("RiderApplicationEditForm-description");
+            const notesField =getByTestId("RiderApplicationEditForm-notes");
+
+            expect(statusField).toHaveValue("pending");
+            expect(permNumberField).toHaveValue("1234567");
+            expect(emailField).toHaveValue("random@example.org");
+            expect(createdDateField).toHaveValue("2023-04-17");
+            expect(updatedDateField).toHaveValue("2023-04-17");
+            expect(cancelledDateField).toHaveValue("");
+            expect(descriptionField).toHaveValue("");
+            expect(notesField).toHaveValue("");
+            
+        });
+
+        test("Changes when you click Update", async () => {
+
+                
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationEditForm-id");
+
+            const statusField =getByTestId("RiderApplicationEditForm-status");
+            const permNumberField = getByTestId("RiderApplicationEditForm-perm_number");
+            const emailField =getByTestId("RiderApplicationEditForm-email");
+            const createdDateField =getByTestId("RiderApplicationEditForm-created_date");
+            const updatedDateField =getByTestId("RiderApplicationEditForm-updated_date");
+            const cancelledDateField =getByTestId("RiderApplicationEditForm-cancelled_date");
+            const descriptionField = getByTestId("RiderApplicationEditForm-description");
+            const notesField =getByTestId("RiderApplicationEditForm-notes");
+            const submitButton = getByTestId("RiderApplicationEditForm-submit")
+
+            expect(statusField).toHaveValue("pending");
+            expect(permNumberField).toHaveValue("1234567");
+            expect(emailField).toHaveValue("random@example.org");
+            expect(createdDateField).toHaveValue("2023-04-17");
+            expect(updatedDateField).toHaveValue("2023-04-17");
+            expect(cancelledDateField).toHaveValue("");
+            expect(descriptionField).toHaveValue("");
+            expect(notesField).toHaveValue("");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(notesField, { target: { value: "approving" } });
+
+            fireEvent.click(submitButton);
+
+    
+            await waitFor(() => expect(mockToast).toHaveBeenCalled());
+            expect(mockToast).toBeCalledWith("Application Updated - id: 17");
+            expect(mockNavigate).toBeCalledWith({ "to": "/admin/applications/riders" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                perm_number: "1234567",
+                description: "",
+                notes: "approving",
+            })); // posted object
+
+        });
+
+       
+    });
+});

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, screen, render, waitFor } from "@testing-library/react";
+import { screen, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
@@ -27,15 +27,6 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     const axiosMock = new AxiosMockAdapter(axios);
 
     const testId = "RiderApplicationTable";
-
-    const applications = [
-        riderApplicationFixtures.threeRiderApplications[0],
-        riderApplicationFixtures.threeRiderApplications[1],
-        {
-            ...riderApplicationFixtures.threeRiderApplications[2],
-            status: "pending"
-        }
-    ]
 
     const setupMemberOnly = () => {
         axiosMock.reset();

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -1,0 +1,144 @@
+import { fireEvent, screen, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { riderApplicationFixtures } from "fixtures/riderApplicationFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("RiderApplicationIndexPageAdmin tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "RiderApplicationTable";
+
+    const applications = [
+        riderApplicationFixtures.threeRiderApplications[0],
+        riderApplicationFixtures.threeRiderApplications[1],
+        {
+            ...riderApplicationFixtures.threeRiderApplications[2],
+            status: "pending"
+        }
+    ]
+
+    const setupMemberOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.memberOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupMemberOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("renders three rides without crashing for regular user", async () => {
+        setupMemberOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+
+    });
+
+    test("renders three rides without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+
+    });
+
+    test("renders empty table when backend unavailable, member only", async () => {
+        setupMemberOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+});

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
@@ -118,7 +118,7 @@ public class RiderApplicationController extends ApiController {
             application.setPerm_number(incoming.getPerm_number());
             application.setUpdated_date(currentDate);
             application.setDescription(incoming.getDescription());
-
+            application.setNotes(incoming.getNotes());
             riderApplicationRepository.save(application);
             return ResponseEntity.ok(application);
         }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
@@ -405,7 +405,7 @@ public class RiderApplicationControllerTests extends ControllerTestCase {
                         .updated_date(currentDate)
                         .cancelled_date(null)
                         .description("My legs were broken")
-                        .notes("")
+                        .notes("can be approved if proved")
                         .build();
 
         String requestBody = mapper.writeValueAsString(application_edited);

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
@@ -219,7 +219,7 @@ public class RiderApplicationControllerTests extends ControllerTestCase {
 
             when(riderApplicationRepository.save(eq(application1))).thenReturn(application1);
 
-            String postRequesString = "perm_number=7654321&description=My leg is broken";
+            String postRequesString = "perm_number=7654321&description=My leg is broken&notes=";
 
             // act
             MvcResult response = mockMvc.perform(


### PR DESCRIPTION
Tasks Completed:

- [x] On the Admin menu there is an option Rider Applications that takes the admin user to a page /admin/applications/riders
- [x] Edited Old Controllers and created new tests to handle edits on the notes field
- [x]  On that page the admin can see separate tables: one labelled Pending Rider Applications with all currently pending rider applications, and a second labelled All Rider Applications which contains all rider applications.
- [x]  Both tables have Review buttons that take the admin to a page /admin/applications/riders/review/:id where the admin can see all of the fields in the application, but can edit the notes field.
- [x] Created tests for Edit forms and Admin pages

On the Admin menu there is an option Rider Applications that takes the admin user to a page /admin/applications/riders
Deployment Link: https://proj-gauchoride-ze-el-dev.dokku-13.cs.ucsb.edu

<img width="1371" alt="Screenshot 2024-03-05 at 6 02 10 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/161cf475-5278-455a-a606-5c3f8c189537">




On that page the admin can see separate tables: one labelled Pending Rider Applications with all currently pending rider applications, and a second labelled All Rider Applications which contains all rider applications.

<img width="1371" alt="Screenshot 2024-03-05 at 6 04 13 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/dd8eab1f-42de-48b2-b35d-f965ecd209d1">



Also both the tables have Review buttons that take the admin to a page /admin/applications/riders/review/:id where the admin can see all of the fields in the application, but can edit the notes field.

<img width="1371" alt="Screenshot 2024-03-05 at 6 05 32 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/d0eb9dfa-9ce9-4403-a31e-d273c9a8f0d7">

<img width="1371" alt="Screenshot 2024-03-05 at 6 05 39 PM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/bf1a125a-c4f8-4dd2-b8cd-0042c24629ee">



Closes #40 