### PR TITLE
LR driver availability controller

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14341,9 +14341,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001485",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
-      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA==",
+      "version": "1.0.30001594",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
+      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
       "funding": [
         {
           "type": "opencollective",
@@ -46664,9 +46664,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001485",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
-      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA=="
+      "version": "1.0.30001594",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
+      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -3,12 +3,15 @@ package edu.ucsb.cs156.gauchoride.controllers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import edu.ucsb.cs156.gauchoride.entities.DriverAvailability;
+import edu.ucsb.cs156.gauchoride.repositories.DriverAvailabilityRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,13 +33,11 @@ public class DriverAvailabilityController extends ApiController{
     public DriverAvailability postDriverAvailability(
             @Parameter(name="driverId") @RequestParam long driverId,
             @Parameter(name="day") @RequestParam String day,
-            @Parameter(name="startTime") @RequestParam int startTime,
+            @Parameter(name="startTime") @RequestParam String startTime,
             @Parameter(name="endTime") @RequestParam String endTime,
             @Parameter(name="notes") @RequestParam String notes)
             throws JsonProcessingException {
 
-        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        // See: https://www.baeldung.com/spring-date-parameters
 
         log.info("notes={}", notes);
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -27,7 +27,7 @@ public class DriverAvailabilityController extends ApiController{
     DriverAvailabilityRepository driverAvailabilityRepository;
 
     //Allows driver to create and post new availability
-    @Operation(summary= "Create a new Driver Availability")
+    @Operation(summary= "Create a new driver availability")
     @PreAuthorize("hasRole('ROLE_DRIVER')")
     @PostMapping("/new")
     public DriverAvailability postDriverAvailability(
@@ -53,9 +53,18 @@ public class DriverAvailabilityController extends ApiController{
         return savedDriverAvailability;
     }
 
+    //GET all availability submissions for the current user.
+    @Operation(summary = "Get all driver availabilites owned by the current user")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @GetMapping("")
+    public Iterable<DriverAvailability> allApplications() {
+        Iterable<DriverAvailability> availabilities;
+        availabilities = driverAvailabilityRepository.findAllByDriverId(getCurrentUser().getUser().getId());
+        return availabilities;
+    }
 
     //Lets admins get all driver availabilties
-    @Operation(summary= "List all Driver Availabilities")
+    @Operation(summary= "List all driver availabilities")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/all")
     public Iterable<DriverAvailability> allDriverAvailabilities() {

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -124,6 +124,21 @@ public class DriverAvailabilityController extends ApiController{
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
 
+    //Lets Admin GET a single availability by ID
+    @Operation(summary = "Admin can get a single availability by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("admin")
+    public DriverAvailability adminGetById(
+                    @Parameter(name="id", description = "Long, Id of the driver availability to get", 
+                    required = true)  
+                    @RequestParam Long id) 
+    {
+        DriverAvailability availability;
+        availability = driverAvailabilityRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+        return availability;
+    }
+
     //Lets admins get all driver availabilties
     @Operation(summary= "List all driver availabilities")
     @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -5,6 +5,7 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -108,6 +109,19 @@ public class DriverAvailabilityController extends ApiController{
         driverAvailabilityRepository.save(availability);
         return ResponseEntity.ok(availability);
 
+    }
+
+    //DELETE for driver Availability
+    @Operation(summary= "Delete a driver availability")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @DeleteMapping("")
+    public Object deleteDriverAvailability(
+            @Parameter(name="id") @RequestParam Long id) {
+        DriverAvailability availability = driverAvailabilityRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+
+        driverAvailabilityRepository.delete(availability);
+        return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
 
     //Lets admins get all driver availabilties

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "DriverAvailability")
+@RequestMapping("/api/driverAvailability")
+@RestController
+@Slf4j
+public class DriverAvailabilityController extends ApiController{
+    
+    @Autowired
+    DriverAvailabilityRepository driverAvailabilityRepository;
+
+    //Allows driver to create and post new availability
+    @Operation(summary= "Create a new Driver Availability")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PostMapping("/new")
+    public DriverAvailability postDriverAvailability(
+            @Parameter(name="driverId") @RequestParam long driverId,
+            @Parameter(name="day") @RequestParam String day,
+            @Parameter(name="startTime") @RequestParam int startTime,
+            @Parameter(name="endTime") @RequestParam String endTime,
+            @Parameter(name="notes") @RequestParam String notes)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("notes={}", notes);
+
+        DriverAvailability driverAvailability = new DriverAvailability();
+        driverAvailability.setDriverId(driverId);
+        driverAvailability.setDay(day);
+        driverAvailability.setStartTime(startTime);
+        driverAvailability.setEndTime(endTime);
+        driverAvailability.setNotes(notes);
+
+        DriverAvailability savedDriverAvailability = driverAvailabilityRepository.save(driverAvailability);
+
+        return savedDriverAvailability;
+    }
+
+
+    //Lets admins get all driver availabilties
+    @Operation(summary= "List all Driver Availabilities")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public Iterable<DriverAvailability> allDriverAvailabilities() {
+        Iterable<DriverAvailability> availabilities = driverAvailabilityRepository.findAll();
+        return availabilities;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverAvailabilityRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverAvailabilityRepository.java
@@ -3,7 +3,11 @@ import edu.ucsb.cs156.gauchoride.entities.DriverAvailability;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DriverAvailabilityRepository extends CrudRepository<DriverAvailability, Long> {
-    
+    Iterable<DriverAvailability> findAllById(long id);
+    Iterable<DriverAvailability> findAllByDriverId(long driverId);
+    Optional<DriverAvailability> findByIdAndDriverId(Long id, Long driverId);
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -1,0 +1,162 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.DriverAvailability;
+import edu.ucsb.cs156.gauchoride.repositories.DriverAvailabilityRepository;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = DriverAvailabilityController.class)
+@Import(TestConfig.class)
+public class DriverAvailabilityControllerTests extends ControllerTestCase {
+
+    @MockBean
+    DriverAvailabilityRepository driverAvailabilityRepository;
+    
+    @MockBean
+    UserRepository userRepository;
+
+    // Test for POST /api/driverAvailability/new
+
+    // Authorization tests for post /api/driverAvailability/new
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability/new"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void logged_in_admin_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability/new"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability/new"))
+                            .andExpect(status().is(403));
+    }
+
+    // POST
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void a_driver_can_post_a_new_driverAvailability() throws Exception {
+        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+
+        DriverAvailability availability1 = DriverAvailability.builder()
+                        .driverId(1)
+                        .day("03/05/2024")
+                        .startTime("10:30AM")
+                        .endTime("2:30PM")
+                        .notes("End for late lunch")
+                        .build();
+
+        when(driverAvailabilityRepository.save(eq(availability1))).thenReturn(availability1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        post("/api/driverAvailability/new?driverId=1&day=03/05/2024&startTime=10:30AM&endTime=2:30PM&notes=End for late lunch")
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).save(availability1);
+        String expectedJson = mapper.writeValueAsString(availability1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // Test for GET /api/driverAvailability/admin/all
+        
+    // Authorization tests for get /api/driverAvailability/admin/all
+    @Test
+    public void logged_out_users_cannot_get_all_Admin() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                            .andExpect(status().is(403));
+   }
+
+   @WithMockUser(roles = { "DRIVER" })
+   @Test
+   public void logged_in_drivers_cannot_get_all_Admin() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                            .andExpect(status().is(403));
+   }
+
+   @WithMockUser(roles = { "RIDER" })
+   @Test
+   public void logged_in_riders_cannot_get_all_Admin() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                            .andExpect(status().is(403));
+   }
+
+   @WithMockUser(roles = { "ADMIN" })
+   @Test
+   public void logged_in_admins_can_get_all_Admin() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                            .andExpect(status().is(200));
+    }
+
+
+    // GET ALL ADMIN
+    @WithMockUser(roles = { "ADMIN", "MEMBER" })
+    @Test
+    public void test_that_logged_in_admin_can_get_all_applications() throws Exception
+    {
+        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+        Long otherUserId = UserId + 1;
+
+        DriverAvailability availability1 = DriverAvailability.builder()
+                        .driverId(1)
+                        .day("02/29/2024")
+                        .startTime("10:30AM")
+                        .endTime("2:30PM")
+                        .notes("End for late lunch")
+                        .build();
+
+        DriverAvailability availability2 = DriverAvailability.builder()
+                        .driverId(1)
+                        .day("03/05/2024")
+                        .startTime("12:30PM")
+                        .endTime("5:30PM")
+                        .notes("Last shift of the day")
+                        .build();
+        
+        ArrayList<DriverAvailability> expectedAvailabilities = new ArrayList<>();
+        expectedAvailabilities.addAll(Arrays.asList(availability1, availability2));
+
+        when(driverAvailabilityRepository.findAll()).thenReturn(expectedAvailabilities);
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability/admin/all"))
+        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedAvailabilities);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -2,12 +2,15 @@ package edu.ucsb.cs156.gauchoride.controllers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -151,6 +154,180 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
+    // Test for GET /api/driverAvailability/id
+
+    // Authorization tests for GET /api/driverAvailability/id
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability/id"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void logged_in_admin_cannot_get_by_id() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_cannot_get_by_id() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+
+    // GET BY ID
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void test_that_logged_in_driver_can_get_by_id_when_the_id_exists_and_user_id_matches() throws Exception {
+        
+        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+
+        DriverAvailability availability = DriverAvailability.builder()
+                        .driverId(1)
+                        .day("03/05/2024")
+                        .startTime("10:30AM")
+                        .endTime("2:30PM")
+                        .notes("End for late lunch")
+                        .build();
+
+        when(driverAvailabilityRepository.findById(eq(7L))).thenReturn(Optional.of(availability));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability/id?id=7"))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(availability);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void test_that_logged_in_driver_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(driverAvailabilityRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability/id?id=7"))
+                        .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+
+        verify(driverAvailabilityRepository, times(1)).findById(eq(7L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("DriverAvailability with id 7 not found", json.get("message"));
+    }
+
+
+    // Test for PUT /api/driverAvailability
+    
+    // Authorization tests for put /api/riderApplication/
+    @Test
+    public void logged_out_users_cannot_edit() throws Exception {
+            mockMvc.perform(put("/api/driverAvailability?id=9"))
+                            .andExpect(status().is(403));
+   }
+
+   @WithMockUser(roles = { "ADMIN" })
+   @Test
+   public void logged_in_admin_cannot_edit() throws Exception {
+           mockMvc.perform(put("/api/driverAvailability?id=9"))
+                           .andExpect(status().is(403));
+   }
+
+   @WithMockUser(roles = { "RIDER" })
+   @Test
+   public void logged_in_rider_cannot_edit() throws Exception {
+           mockMvc.perform(put("/api/driverAvailability?id=9"))
+                           .andExpect(status().is(403));
+   }
+
+    // EDIT (UPDATE)
+
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void driver_can_edit_their_own_availability() throws Exception {
+
+        Long DriverId = currentUserService.getCurrentUser().getUser().getId();
+
+        DriverAvailability availability_original = DriverAvailability.builder()
+                        .driverId(DriverId)
+                        .day("03/05/2024")
+                        .startTime("10:30AM")
+                        .endTime("2:30PM")
+                        .notes("End for late lunch")
+                        .build();
+
+        DriverAvailability availability_edited = DriverAvailability.builder()
+                        .driverId(7)
+                        .day("12/24/2024")
+                        .startTime("5:00AM")
+                        .endTime("12:00PM")
+                        .notes("Early Shift")
+                        .build();
+
+        String requestBody = mapper.writeValueAsString(availability_edited);
+
+        when(driverAvailabilityRepository.findById(eq(67L))).thenReturn(Optional.of(availability_original));
+
+        // act
+        MvcResult response = mockMvc.perform(
+        put("/api/driverAvailability?id=67")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8")
+                            .content(requestBody)
+                            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findById(eq(67L));
+        verify(driverAvailabilityRepository, times(1)).save(availability_edited); // should be saved with correct user
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void driver_cannot_edit_availability_that_does_not_exist() throws Exception {
+            // arrange
+
+            Long DriverId = currentUserService.getCurrentUser().getUser().getId();
+
+            DriverAvailability availability_edited = DriverAvailability.builder()
+                        .driverId(DriverId)
+                        .day("12/24/2024")
+                        .startTime("5:00AM")
+                        .endTime("12:00PM")
+                        .notes("Early Shift")
+                        .build();
+                        
+            String requestBody = mapper.writeValueAsString(availability_edited);
+
+            when(driverAvailabilityRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/driverAvailability?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(driverAvailabilityRepository, times(1)).findById(67L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("DriverAvailability with id 67 not found", json.get("message"));
+
+    }
+
     // Test for GET /api/driverAvailability/admin/all
         
     // Authorization tests for get /api/driverAvailability/admin/all

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -23,7 +23,7 @@ import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -232,21 +232,21 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     // Authorization tests for put /api/riderApplication/
     @Test
     public void logged_out_users_cannot_edit() throws Exception {
-            mockMvc.perform(put("/api/driverAvailability?id=9"))
+            mockMvc.perform(put("/api/driverAvailability/id?id=9"))
                             .andExpect(status().is(403));
    }
 
    @WithMockUser(roles = { "ADMIN" })
    @Test
    public void logged_in_admin_cannot_edit() throws Exception {
-           mockMvc.perform(put("/api/driverAvailability?id=9"))
+           mockMvc.perform(put("/api/driverAvailability/id?id=9"))
                            .andExpect(status().is(403));
    }
 
    @WithMockUser(roles = { "RIDER" })
    @Test
    public void logged_in_rider_cannot_edit() throws Exception {
-           mockMvc.perform(put("/api/driverAvailability?id=9"))
+           mockMvc.perform(put("/api/driverAvailability/id?id=9"))
                            .andExpect(status().is(403));
    }
 
@@ -327,6 +327,77 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             assertEquals("DriverAvailability with id 67 not found", json.get("message"));
 
     }
+
+    // Test for DELETE api/driverAvailability
+
+    // Authorization tests for DELETE /api/riderApplication/
+     @Test
+     public void logged_out_users_cannot_delete() throws Exception {
+             mockMvc.perform(put("/api/driverAvailability"))
+                             .andExpect(status().is(403));
+    }
+ 
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void logged_in_admin_cannot_delete() throws Exception {
+            mockMvc.perform(put("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+ 
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_cannot_delete() throws Exception {
+            mockMvc.perform(put("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void driver_can_delete_an_availability() throws Exception {
+        // arrange
+
+        DriverAvailability availability = DriverAvailability.builder()
+                .driverId(1)
+                .day("12/24/2024")
+                .startTime("5:00AM")
+                .endTime("12:00PM")
+                .notes("Early Shift")
+                .build();
+
+        when(driverAvailabilityRepository.findById(eq(15L))).thenReturn(Optional.of(availability));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/driverAvailability?id=15")
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findById(15L);
+        verify(driverAvailabilityRepository, times(1)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("DriverAvailability with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_tries_to_delete_non_existant_availability_and_gets_right_error_message() throws Exception {
+            // arrange
+
+            when(driverAvailabilityRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/driverAvailability?id=15")
+                                                .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(driverAvailabilityRepository, times(1)).findById(15L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("DriverAvailability with id 15 not found", json.get("message"));
+        }
 
     // Test for GET /api/driverAvailability/admin/all
         

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -89,6 +89,68 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
 
+    // Test for GET /api/driverAvailability
+
+    // Authorization tests for GET /api/driverAvailability
+    @Test
+    public void logged_out_users_cannot_get() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void logged_in_admin_cannot_get() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_cannot_get() throws Exception {
+            mockMvc.perform(post("/api/driverAvailability"))
+                            .andExpect(status().is(403));
+    }
+
+    //  GET ALL
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void logged_in_driver_can_get_all_their_own_availabilities() throws Exception {
+
+        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+
+        DriverAvailability availability1 = DriverAvailability.builder()
+                        .driverId(1)
+                        .day("03/05/2024")
+                        .startTime("10:30AM")
+                        .endTime("2:30PM")
+                        .notes("End for late lunch")
+                        .build();
+
+        DriverAvailability availability2 = DriverAvailability.builder()
+                        .driverId(2)
+                        .day("12/24/2024")
+                        .startTime("5:00AM")
+                        .endTime("12:00PM")
+                        .notes("Early Shift")
+                        .build();
+
+        ArrayList<DriverAvailability> expectedAvailabilities = new ArrayList<>();
+        expectedAvailabilities.addAll(Arrays.asList(availability1, availability2));
+
+        when(driverAvailabilityRepository.findAllByDriverId(eq(UserId))).thenReturn(expectedAvailabilities);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability"))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(driverAvailabilityRepository, times(1)).findAllByDriverId(eq(UserId));
+        String expectedJson = mapper.writeValueAsString(expectedAvailabilities);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
     // Test for GET /api/driverAvailability/admin/all
         
     // Authorization tests for get /api/driverAvailability/admin/all


### PR DESCRIPTION
In this PR I added a Driver Availability Controller with the endpoints in the screenshot below as well as tests for them. I did have to change the GET by ID endpoint to /api/driverAvailability/id?id=123 as there was already a GET endpoint for /api/driverAvailability

Also here is prod deployment link: https://proj-gauchoride-liamlizard-dev.dokku-13.cs.ucsb.edu
I realized though that it does not have swagger so it does not really help to see the changes.

<img width="902" alt="Screenshot 2024-03-06 at 8 55 50 AM" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/82777456/22f3df0c-c875-45c8-9289-dc181e1e147f">

Closes #11 