### PR TITLE
OP - added functionality where Admins can assign a shiftId to a Ride …

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,12 +8,14 @@ import DriverListPage from "main/pages/DriverListPage";
 import RideRequestCreatePage from "main/pages/Ride/RideRequestCreatePage";
 import RideRequestEditPage from "main/pages/Ride/RideRequestEditPage";
 import RideRequestIndexPage from "main/pages/Ride/RideRequestIndexPage";
+import RideRequestAssignPage from "main/pages/Ride/RideRequestAssignPage";
 import ShiftPage from "main/pages/ShiftPage";
 import ChatPage from "main/pages/ChatPage";
 
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
 import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
 import ShiftIndexPage from "main/pages/Shift/ShiftIndexPage";
+import ShiftInfoPage from "main/pages/Shift/ShiftInfoPage";
 
 import DriverPage from "main/pages/DriverPage";
 import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
@@ -52,6 +54,9 @@ function App() {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_RIDER")) && <Route exact path="/ride/" element={<RideRequestIndexPage />} />
         }
         {
+          hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/ride/assigndriver/:id" element={<RideRequestAssignPage />} />
+        }
+        {
           (hasRole(currentUser, "ROLE_RIDER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/ride/create" element={<RideRequestCreatePage />} />
         }
         {
@@ -84,6 +89,10 @@ function App() {
         {
           (hasRole(currentUser, "ROLE_DRIVER") ) && <Route exact path="/drivershifts" element={<DriverDashboardPage />} />
         }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN")  || hasRole(currentUser, "ROLE_DRIVER") )&& <Route exact path="/shiftInfo/:id" element={<ShiftInfoPage />} />
+        }
+        {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider" element={<RiderApplicationIndexPageMember />} />
         }
         {

--- a/frontend/src/fixtures/rideFixtures.js
+++ b/frontend/src/fixtures/rideFixtures.js
@@ -11,7 +11,8 @@ const rideFixtures = {
         "dropoffRoom": "123",
         "pickupRoom" : "111",
         "course": "CMPSC111",
-        "notes": ""    
+        "notes": "",
+        "shiftId": "2"
       }
     ],
     threeRidesTable:
@@ -28,7 +29,8 @@ const rideFixtures = {
             "dropoffRoom": "123",
             "pickupRoom": "124",
             "course": "CMPSC64",
-            "notes": "N/A"
+            "notes": "N/A",
+            "shiftId": "2"
         },
 
         {
@@ -43,7 +45,8 @@ const rideFixtures = {
             "dropoffRoom": "123",
             "pickupRoom": "125",
             "course": "CMPSC138",
-            "notes": "Hi"
+            "notes": "Hi",
+            "shiftId": "100"
         },
 
         {
@@ -59,6 +62,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC156",
             "notes": "2 people",   
+            "shiftId": "10"
         },
         
     ],
@@ -74,7 +78,8 @@ const rideFixtures = {
             "dropoffRoom": "123",
             "pickupRoom": "125",
             "course": "CMPSC64",
-            "notes": "3rides1",      
+            "notes": "3rides1",
+            "shiftId": "2"
         },
 
         {
@@ -88,6 +93,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC138",
             "notes": "3rides2",
+            "shiftId": "7"
         },
 
         {
@@ -101,6 +107,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC156",
             "notes": "3rides3",
+            "shiftId": "3"
         },
         
     ]

--- a/frontend/src/main/components/Ride/RideAssignDriverForm.js
+++ b/frontend/src/main/components/Ride/RideAssignDriverForm.js
@@ -1,0 +1,195 @@
+import React from 'react'
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+
+
+function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "Assign Driver" }) {
+    const navigate = useNavigate();
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents }
+    );
+    // Stryker enable all
+   
+    const testIdPrefix = "RideAssignDriverForm";
+
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        defaultValue={initialContents.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="shiftId">Shift Id</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-shiftId"}
+                    id="shiftId"
+                    type="text"
+                    isInvalid={Boolean(errors.pickupBuilding)}
+                    {...register("shiftId", {
+                        required: "Shift Id Up Building is required."
+                    })}
+                    defaultValue={initialContents?.pickupBuilding} 
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.pickupBuilding?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="day">Day of Week</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-day"}
+                    id="day"
+                    isInvalid={Boolean(errors.day)}
+                    {...register("day")}
+                    disabled
+                    defaultValue={initialContents?.day}
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="start">Start Time</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-start"}
+                    id="start"
+                    type="text"
+                    {...register("start")}
+                    disabled
+                    defaultValue={initialContents?.startTime}
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="end">End Time</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-end"}
+                    id="end"
+                    type="text"
+                    {...register("end")}
+                    disabled
+                    defaultValue={initialContents?.endTime}     
+                />
+            </Form.Group>
+            
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="pickupBuilding">Pick Up Building</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-pickupBuilding"}
+                    id="pickupBuilding"
+                    type="text"
+                    isInvalid={Boolean(errors.pickupBuilding)}
+                    {...register("pickupBuilding")}
+                    disabled
+                    defaultValue={initialContents?.pickupBuilding} 
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="pickupRoom">Room Number for Pickup</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-pickupRoom"}
+                    id="pickupRoom"
+                    type="text"
+                    isInvalid={Boolean(errors.pickupRoom)}
+                    {...register("pickupRoom")}
+                    disabled
+                    defaultValue={initialContents?.pickupRoom} 
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="dropoffBuilding">Drop Off Building</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-dropoffBuilding"}
+                    id="dropoffBuilding"
+                    type="text"
+                    isInvalid={Boolean(errors.dropoffBuilding)}
+                    {...register("dropoffBuilding")}
+                    disabled
+                    defaultValue={initialContents?.dropoffBuilding}
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="dropoffRoom">Room Number for Dropoff</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-dropoffRoom"}
+                    id="dropoffRoom"
+                    type="text"
+                    isInvalid={Boolean(errors.dropoffRoom)}
+                    {...register("dropoffRoom")}
+                    disabled
+                    defaultValue={initialContents?.dropoffRoom} 
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="course">Course Number</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-course"}
+                    id="course"
+                    type="text"
+                    isInvalid={Boolean(errors.course)}
+                    {...register("course")}
+                    disabled
+                    defaultValue={initialContents?.course} 
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="notes">Notes</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-notes"}
+                    id="notes"
+                    type="text"
+                    isInvalid={Boolean(errors.notes)}
+                    {...register("notes")}
+                    disabled
+                    defaultValue={initialContents?.notes} 
+                />
+            </Form.Group>
+
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default RideAssignDriverForm;

--- a/frontend/src/main/components/Ride/RideTable.js
+++ b/frontend/src/main/components/Ride/RideTable.js
@@ -4,6 +4,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/rideUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
+import { Link } from "react-router-dom";
 
 export default function RideTable({
         ride,
@@ -14,6 +15,10 @@ export default function RideTable({
 
     const editCallback = (cell) => {
         navigate(`/ride/edit/${cell.row.values.id}`)
+    }
+
+    const assignCallback = (cell) => {
+        navigate(`/ride/assigndriver/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching
@@ -43,8 +48,12 @@ export default function RideTable({
             accessor: 'student',
         },
         {
-            Header: 'Driver',
-            accessor: 'driver',
+            Header: 'Shift',
+            accessor: 'shiftId',
+            Cell: ({ value }) => (
+                // Stryker disable next-line all : hard to set up test
+                <Link to={`/shiftInfo/${value}`}>{value}</Link>
+              ),
         },
         {
             Header: 'Course #',
@@ -94,6 +103,14 @@ export default function RideTable({
             accessor: 'student',
         },
         {
+            Header: 'Shift',
+            accessor: 'shiftId',
+            Cell: ({ value }) => (
+                // Stryker disable next-line all : hard to set up test
+                <Link to={`/shiftInfo/${value}`}>{value}</Link>
+              ),
+        },
+        {
             Header: 'Course #',
             accessor: 'course',
         },
@@ -135,10 +152,6 @@ export default function RideTable({
         {
             Header: 'Day',
             accessor: 'day',
-        },
-        {
-            Header: 'Driver',
-            accessor: 'driver',
         },
         {
             Header: 'Course #',
@@ -184,7 +197,8 @@ export default function RideTable({
     const buttonColumnsAdmin = [
         ...columns,
         ButtonColumn("Edit", "primary", editCallback, "RideTable"),
-        ButtonColumn("Delete", "danger", deleteCallback, "RideTable")
+        ButtonColumn("Delete", "danger", deleteCallback, "RideTable"),
+        ButtonColumn("Assign Driver", "success", assignCallback, "RideTable")
     ]
 
    

--- a/frontend/src/main/components/Shift/ShiftInfo.js
+++ b/frontend/src/main/components/Shift/ShiftInfo.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Card from 'react-bootstrap/Card';
+
+function ShiftInfo({ info }) {
+  return (
+    <Card data-testid="DriverInfo">
+      <Card.Body>
+          <Card.Title>{'Id: ' + info.id}</Card.Title>
+          <Card.Title>{'Day: ' + info.day}</Card.Title>
+          <Card.Title>{'Start: ' + info.shiftStart}</Card.Title>
+          <Card.Title>{'End: ' + info.shiftEnd}</Card.Title>
+          <Card.Title>{'Driver Id: ' + info.driverID}</Card.Title>
+          <Card.Title>{'Driver Backup Id: ' + info.driverBackupID}</Card.Title>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default ShiftInfo;

--- a/frontend/src/main/components/Shift/ShiftTable.js
+++ b/frontend/src/main/components/Shift/ShiftTable.js
@@ -18,6 +18,10 @@ export default function ShiftTable({
         navigate(`/shift/edit/${cell.row.values.id}`)
     }
 
+    const infoCallback = (cell) => {
+        navigate(`/shiftInfo/${cell.row.values.id}`)
+    }
+
     // Stryker disable all : hard to test for query caching
 
     const deleteMutation = useBackendMutation(
@@ -68,7 +72,11 @@ export default function ShiftTable({
     if (hasRole(currentUser, "ROLE_ADMIN")) {
         columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
-    } 
+    }
+    
+    if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_DRIVER")) {
+        columns.push(ButtonColumn("Info", "success", infoCallback, testIdPrefix))
+    }
 
     return <OurTable
         data={shift}

--- a/frontend/src/main/pages/Ride/RideRequestAssignPage.js
+++ b/frontend/src/main/pages/Ride/RideRequestAssignPage.js
@@ -1,0 +1,68 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import RideAssignDriverForm from "main/components/Ride/RideAssignDriverForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+
+import { toast } from "react-toastify";
+
+export default function RideRequestAssignPage() {
+  let { id } = useParams();
+
+  const { data: ride, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/ride_request?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/ride_request`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (ride) => ({
+    url: "/api/ride_request/assigndriver",
+    method: "PUT",
+    params: {
+      id: ride.id,
+    },
+    data: {
+        shiftId: ride.shiftId,
+    }
+  });
+
+  const onSuccess = (ride) => {
+    toast(`Driver Assigned - id: ${ride.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ride_request/assigndriver?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/ride/" />
+  }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Assign Driver to Ride Request</h1>
+                {ride &&
+                <RideAssignDriverForm initialContents={ride} submitAction={onSubmit} buttonLabel="Assign Driver" />
+                }
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/Shift/ShiftInfoPage.js
+++ b/frontend/src/main/pages/Shift/ShiftInfoPage.js
@@ -1,0 +1,66 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import { useBackend } from "main/utils/useBackend";
+import ShiftInfo from "main/components/Shift/ShiftInfo";
+import RideTable from 'main/components/Ride/RideTable';
+import { Button } from 'react-bootstrap';
+import {useCurrentUser } from 'main/utils/currentUser'
+
+export default function ShiftInfoPage() {
+    const currentUser = useCurrentUser();
+    let { id } = useParams();
+
+    const { data: info, _error, _status } =
+      useBackend(
+        // Stryker disable next-line all : don't test internal caching of React Query
+        [`/api/shift?id=${id}`],
+        {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+          method: "GET",
+          url: `/api/shift`,
+          // Stryker disable all
+          params: {
+            id
+          }
+          // Stryker restore all
+        }
+      );
+
+    const { data: rides, error: _errorRides, status: _statusRides } =
+    useBackend(
+      // Stryker disable all : hard to test for query caching
+      [`/api/ride_request/shiftId?shiftId=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/ride_request/shiftId`,
+        // Stryker disable all
+        params: {
+          shiftId: id
+        }
+        // Stryker restore all
+      },
+      []
+    );
+      
+    const returnButton = () => {
+        return (
+            <Button
+                variant="primary"
+                href="/ride/"
+            >
+                Return
+            </Button>
+        )
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Shift Info</h1>
+                {info && <div className="pb-3"><ShiftInfo info={ info }/></div>}
+                <h1>Associated Ride Requests</h1>
+                <RideTable ride={rides} currentUser={currentUser} />
+                {returnButton()}
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/stories/components/Ride/RideAssignDriverForm.stories.js
+++ b/frontend/src/stories/components/Ride/RideAssignDriverForm.stories.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import RideFormAssignDriverForm from "main/components/Ride/RideAssignDriverForm"
+import { rideFixtures } from 'fixtures/rideFixtures';
+
+export default {
+    title: 'components/Ride/RideAssignDriverForm',
+    component: RideFormAssignDriverForm
+};
+
+const Template = (args) => {
+    return (
+        <RideFormAssignDriverForm {...args} />
+    )
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+    initialContents: rideFixtures.threeRides[0],
+    buttonLabel: "Assign Driver",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/Shift/ShiftInfo.stories.js
+++ b/frontend/src/stories/components/Shift/ShiftInfo.stories.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ShiftInfo from 'main/components/Shift/ShiftInfo';
+import { shiftFixtures } from 'fixtures/shiftFixtures';
+
+export default {
+    title: 'Components/ShiftInfo',
+    component: ShiftInfo,
+};
+
+const Template = (args) => <ShiftInfo {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    info: shiftFixtures.threeShifts[0],
+};

--- a/frontend/src/stories/components/Shift/ShiftInfoPage.stories.js
+++ b/frontend/src/stories/components/Shift/ShiftInfoPage.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import ShiftInfoPage from 'main/pages/Shift/ShiftInfoPage';
+import { shiftFixtures } from 'fixtures/shiftFixtures';
+
+export default {
+    title: 'pages/Shift/ShiftInfoPage',
+    component: ShiftInfoPage
+};
+
+const Template = () => <ShiftInfoPage />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+    initialContents: shiftFixtures.oneShift
+};

--- a/frontend/src/stories/components/Shift/ShiftTable.stories.js
+++ b/frontend/src/stories/components/Shift/ShiftTable.stories.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import ShiftTable from "main/components/Shift/ShiftTable";
 import shiftFixtures from 'fixtures/shiftFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
     title: 'components/Shift/ShiftTable',
@@ -27,4 +28,15 @@ ThreeShifts.args = {
     shift: shiftFixtures.threeShifts
 };
 
+export const DriverThreeSubjectsWithButtons = Template.bind({});
+DriverThreeSubjectsWithButtons.args = {
+    shift: shiftFixtures.threeShifts,
+    currentUser: currentUserFixtures.driverOnly
+};
+
+export const AdminThreeSubjectsWithButtons = Template.bind({});
+AdminThreeSubjectsWithButtons.args = {
+    shift: shiftFixtures.threeShifts,
+    currentUser: currentUserFixtures.adminUser
+};
 

--- a/frontend/src/stories/pages/Ride/RideRequestAssignPage.stories.js
+++ b/frontend/src/stories/pages/Ride/RideRequestAssignPage.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import RideRequestAssignPage from 'main/pages/Ride/RideRequestAssignPage';
+import { rideFixtures } from 'fixtures/rideFixtures';
+
+export default {
+    title: 'pages/Ride/RideRequestAssignPage',
+    component: RideRequestAssignPage
+};
+
+const Template = () => <RideRequestAssignPage />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+    initialContents: rideFixtures.oneRide
+};

--- a/frontend/src/tests/components/Ride/RideAssignDriverForm.test.js
+++ b/frontend/src/tests/components/Ride/RideAssignDriverForm.test.js
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import RideAssignDriverForm from "main/components/Ride/RideAssignDriverForm";
+import { rideFixtures } from "fixtures/rideFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("RideAssignDriverForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Shift Id", "Day of Week", "Start Time", "End Time", "Pick Up Building", "Drop Off Building", "Room Number for Dropoff", "Course Number"];
+    const testId = "RideAssignDriverForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RideAssignDriverForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Assign Driver/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+          });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RideAssignDriverForm initialContents={rideFixtures.oneRide} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Assign Driver/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+        expect(screen.getByText(`Id`)).toBeInTheDocument();
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RideAssignDriverForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+});

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -91,8 +91,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Student','Shift', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Student','Shift', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'pickUpTime', 'dropOffTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     await waitFor(() => {
@@ -141,8 +141,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'course', 'pickUpTime', 'dropOffTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -195,22 +195,17 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Student', 'Shift', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Student', 'Shift', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'pickUpTime', 'dropOffTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
-    await waitFor(() => {
-      expectedHeaders.forEach((headerText) => {
-        const header = getByText(headerText);
-        expect(header).toBeInTheDocument();
-      });
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
-
-    await waitFor(() => {
-      expectedFields.forEach((field) => {
-        const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
-        expect(header).toBeInTheDocument();
-      });
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
     });
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -78,7 +78,7 @@ describe("RideTable tests", () => {
   });
 
 
-  test("Has the expected column headers and content for adminUser", () => {
+  test("Has the expected column headers and content for adminUser", async () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
@@ -95,14 +95,18 @@ describe("RideTable tests", () => {
     const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
-    expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
-      expect(header).toBeInTheDocument();
+    await waitFor(() => {
+      expectedHeaders.forEach((headerText) => {
+        const header = getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
     });
 
-    expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(header).toBeInTheDocument();
+    await waitFor(() => {
+      expectedFields.forEach((field) => {
+        const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
     });
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
@@ -124,7 +128,7 @@ describe("RideTable tests", () => {
 
 
 
-  test("Has the expected column headers and content for ordinary rider", () => {
+  test("Has the expected column headers and content for ordinary rider", async () => {
 
     const currentUser = currentUserFixtures.userOnly;
 
@@ -151,6 +155,20 @@ describe("RideTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
+    await waitFor(() => {
+      expectedHeaders.forEach((headerText) => {
+        const header = getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+    });
+
+    await waitFor(() => {
+      expectedFields.forEach((field) => {
+        const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+    });
+
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
 
@@ -164,7 +182,7 @@ describe("RideTable tests", () => {
     
   });
 
-  test("Has the expected column headers and content for ordinary driver", () => {
+  test("Has the expected column headers and content for ordinary driver", async () => {
 
     const currentUser = currentUserFixtures.driverOnly;
 
@@ -181,14 +199,18 @@ describe("RideTable tests", () => {
     const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
-    expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
-      expect(header).toBeInTheDocument();
+    await waitFor(() => {
+      expectedHeaders.forEach((headerText) => {
+        const header = getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
     });
 
-    expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(header).toBeInTheDocument();
+    await waitFor(() => {
+      expectedFields.forEach((field) => {
+        const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
     });
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -91,8 +91,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Student','Driver', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'student', 'driver', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Student','Shift', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -115,6 +115,10 @@ describe("RideTable tests", () => {
     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
+
+    const assignButton = getByTestId(`${testId}-cell-row-0-col-Assign Driver-button`);
+    expect(assignButton).toBeInTheDocument();
+    expect(assignButton).toHaveClass("btn-success");
 
   });
 
@@ -133,8 +137,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Driver', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day',  'driver', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -157,7 +161,7 @@ describe("RideTable tests", () => {
     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
-
+    
   });
 
   test("Has the expected column headers and content for ordinary driver", () => {
@@ -173,8 +177,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day','Student', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'student', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day','Student', 'Shift', 'Course #', 'Start Time', 'End Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'student', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -266,5 +270,28 @@ describe("RideTable tests", () => {
     expect(mockDeleteMutation).toHaveBeenCalled();
   });
   
-  
+  test("Assign driver button navigates to the assign driver page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RideTable ride={rideFixtures.threeRidesTable} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(getByTestId(`RideTable-cell-row-0-col-id`)).toHaveTextContent("2"); });
+
+    const assignDriverButton = getByTestId(`RideTable-cell-row-0-col-Assign Driver-button`);
+    expect(assignDriverButton).toBeInTheDocument();
+    
+    fireEvent.click(assignDriverButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ride/assigndriver/2'));
+
+  });
+
 });

--- a/frontend/src/tests/components/Shift/ShiftInfo.test.js
+++ b/frontend/src/tests/components/Shift/ShiftInfo.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ShiftInfo from 'main/components/Shift/ShiftInfo';
+import shiftFixtures from 'fixtures/shiftFixtures';
+
+describe('ShiftInfo test', () => {
+    test('renders shift information correctly', () => {
+    render(<ShiftInfo info={shiftFixtures.oneShift[0]} />);
+
+        const card = screen.getByTestId('DriverInfo');
+        expect(card).toBeInTheDocument();
+
+        expect(screen.getByText('Id: 1')).toBeInTheDocument();
+        expect(screen.getByText('Day: Friday')).toBeInTheDocument();
+        expect(screen.getByText('Start: 09:00AM')).toBeInTheDocument();
+        expect(screen.getByText('End: 10:00AM')).toBeInTheDocument();
+        expect(screen.getByText('Driver Id: 1')).toBeInTheDocument();
+        expect(screen.getByText('Driver Backup Id: 2')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/tests/components/Shift/ShiftTable.test.js
+++ b/frontend/src/tests/components/Shift/ShiftTable.test.js
@@ -74,7 +74,7 @@ describe("ShiftTable tests", () => {
 
 
       test("Has the expected column headers, content, and buttons for admin user", () => {
-        const currentUser = currentUserFixtures.adminUser;
+        const currentUser = currentUserFixtures.adminOnly;
         
         render(
             <QueryClientProvider client={queryClient}>
@@ -104,7 +104,40 @@ describe("ShiftTable tests", () => {
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
         expect(deleteButton).toHaveClass("btn-danger");
+
+        const infoButton = screen.getByTestId(`${testId}-cell-row-0-col-Info-button`);
+        expect(infoButton).toBeInTheDocument();
+        expect(infoButton).toHaveClass("btn-success");
     });
+
+    test("Has the expected column headers, content, and buttons for driver user", () => {
+      const currentUser = currentUserFixtures.driverOnly;
+      
+      render(
+          <QueryClientProvider client={queryClient}>
+              <Router>
+                  <ShiftTable shift={shiftFixtures.threeShifts} currentUser={currentUser} />
+              </Router>
+          </QueryClientProvider>
+      );
+  
+      expectedHeaders.forEach((headerText) => {
+          const header = screen.getByText(headerText);
+          expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+          const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+          expect(cellContent).toBeInTheDocument();
+      });
+  
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
+
+      const infoButton = screen.getByTestId(`${testId}-cell-row-0-col-Info-button`);
+      expect(infoButton).toBeInTheDocument();
+      expect(infoButton).toHaveClass("btn-success");
+  });
     
     test("Has the expected column headers and content for an ordinary user", () => {
         const currentUser = currentUserFixtures.userOnly;
@@ -132,6 +165,7 @@ describe("ShiftTable tests", () => {
     
         expect(screen.queryByText("Delete")).not.toBeInTheDocument();
         expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+        expect(screen.queryByText("Info")).not.toBeInTheDocument();
     });
 
     test("Delete button calls delete callback", async () => {
@@ -206,5 +240,28 @@ describe("ShiftTable tests", () => {
     // assert - check that we navigated to the expected path
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/shift/edit/1'));
   });
+
+    test("Info button triggers navigation", async () => {
+      const currentUser = currentUserFixtures.adminUser;
+    
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ShiftTable shift={shiftFixtures.threeShifts} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+    
+      // assert - check that the expected content is rendered
+      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+      const infoButton = screen.getByTestId(`${testId}-cell-row-0-col-Info-button`);
+      expect(infoButton).toBeInTheDocument();
+    
+      // act - click the info button
+      fireEvent.click(infoButton);
+    
+      // assert - check if the mocked navigate function was called
+      expect(mockedNavigate).toHaveBeenCalledWith('/shiftInfo/1');
+    });
 
 });

--- a/frontend/src/tests/pages/Ride/RideRequestAssignPage.test.js
+++ b/frontend/src/tests/pages/Ride/RideRequestAssignPage.test.js
@@ -1,0 +1,219 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import RideRequestAssignPage from "main/pages/Ride/RideRequestAssignPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("RideRequestAssignPage tests", () => {
+
+    describe("when the backend doesn't return a todo", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ride_request", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            const {queryByTestId, findByText} = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RideRequestAssignPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await findByText("Assign Driver to Ride Request");
+            expect(queryByTestId("RideAssignDriverForm-day")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ride_request", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                shiftId: 1,
+                day: "Tuesday",
+                startTime: "5:00PM",
+                endTime: "7:30PM", 
+                pickupBuilding: "HSSB",
+                dropoffBuilding: "SRB",
+                dropoffRoom: "125",
+                pickupRoom: "1111",
+                course: "CMPSC 156",
+                notes: "note1"
+            });
+            axiosMock.onPut('/api/ride_request/assigndriver').reply(200, {
+                id: "17",
+                shiftId: 3,
+                day: "Monday",
+                startTime: "3:30PM",
+                endTime: "4:30PM", 
+                pickupBuilding: "Phelps",
+                dropoffBuilding: "HSSB",
+                dropoffRoom: "1215",
+                pickupRoom: "2222",
+                course: "WRIT 105CD",
+                notes: "note2"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RideRequestAssignPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RideRequestAssignPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RideAssignDriverForm-day");
+            
+            const shiftIdField = getByTestId("RideAssignDriverForm-shiftId")
+            const dayField = getByTestId("RideAssignDriverForm-day");
+            const startTimeField = getByTestId("RideAssignDriverForm-start");
+            const endTimeField = getByTestId("RideAssignDriverForm-end");
+            const pickupBuildingField = getByTestId("RideAssignDriverForm-pickupBuilding");
+            const dropoffBuildingField = getByTestId("RideAssignDriverForm-dropoffBuilding");
+            const dropoffRoomField = getByTestId("RideAssignDriverForm-dropoffRoom");
+            const pickupRoomField = getByTestId("RideAssignDriverForm-pickupRoom");
+            const courseField = getByTestId("RideAssignDriverForm-course");
+            const notesField = getByTestId("RideAssignDriverForm-notes");
+            
+            expect(shiftIdField).toHaveValue("1");
+            expect(dayField).toHaveValue("Tuesday");
+            expect(startTimeField).toHaveValue("5:00PM");
+            expect(endTimeField).toHaveValue("7:30PM");
+            expect(pickupBuildingField).toHaveValue("HSSB");
+            expect(dropoffBuildingField).toHaveValue("SRB");
+            expect(dropoffRoomField).toHaveValue("125");
+            expect(pickupRoomField).toHaveValue("1111");
+            expect(courseField).toHaveValue("CMPSC 156");
+            expect(notesField).toHaveValue("note1");
+            
+        });
+
+        test("Changes when you click Update", async () => {
+
+                
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RideRequestAssignPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RideAssignDriverForm-day");
+
+            const shiftIdField = getByTestId("RideAssignDriverForm-shiftId")
+            const dayField = getByTestId("RideAssignDriverForm-day");
+            const startTimeField = getByTestId("RideAssignDriverForm-start");
+            const endTimeField = getByTestId("RideAssignDriverForm-end");
+            const pickupBuildingField = getByTestId("RideAssignDriverForm-pickupBuilding");
+            const dropoffBuildingField = getByTestId("RideAssignDriverForm-dropoffBuilding");
+            const dropoffRoomField = getByTestId("RideAssignDriverForm-dropoffRoom");
+            const pickupRoomField = getByTestId("RideAssignDriverForm-pickupRoom");
+            const courseField = getByTestId("RideAssignDriverForm-course");
+            const notesField = getByTestId("RideAssignDriverForm-notes");
+            const submitButton = getByTestId("RideAssignDriverForm-submit");
+
+            expect(shiftIdField).toHaveValue("1");
+            expect(dayField).toHaveValue("Tuesday");
+            expect(startTimeField).toHaveValue("5:00PM");
+            expect(endTimeField).toHaveValue("7:30PM");
+            expect(pickupBuildingField).toHaveValue("HSSB");
+            expect(dropoffBuildingField).toHaveValue("SRB");
+            expect(dropoffRoomField).toHaveValue("125");
+            expect(pickupRoomField).toHaveValue("1111")
+            expect(courseField).toHaveValue("CMPSC 156");
+            expect(notesField).toHaveValue("note1");
+
+
+            expect(submitButton).toBeInTheDocument();
+            
+            fireEvent.change(shiftIdField, { target: { value: '3' } })
+            fireEvent.change(dayField, { target: { value: 'Monday' } })
+            fireEvent.change(startTimeField, { target: { value: '3:30PM' } })
+            fireEvent.change(endTimeField, { target: { value: "4:30PM" } })
+            fireEvent.change(pickupBuildingField, { target: { value: 'Phelps' } })
+            fireEvent.change(dropoffBuildingField, { target: { value: 'HSSB' } })
+            fireEvent.change(dropoffRoomField, { target: { value: "1215" } })
+            fireEvent.change(courseField, { target: { value: "WRIT 105CD" } })
+
+
+            fireEvent.click(submitButton);
+
+    
+            await waitFor(() => expect(mockToast).toHaveBeenCalled());
+            expect(mockToast).toBeCalledWith("Driver Assigned - id: 17");
+            expect(mockNavigate).toBeCalledWith({ "to": "/ride/" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                shiftId: "3",
+            })); // posted object
+
+        });
+
+       
+    });
+});

--- a/frontend/src/tests/pages/Shift/ShiftInfoPage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftInfoPage.test.js
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import ShiftInfoPage from "main/pages/Shift/ShiftInfoPage";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("ShiftInfoPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ShiftInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("on submit", async () => {
+        
+        const queryClient = new QueryClient();
+        const info = {
+            "id": "1",
+            "day": "Monday",
+            "shiftStart": "3:30PM",
+            "shiftEnd": "4:00PM",
+            "driverID": "3",
+            "driverBackupID": "4"
+        };
+
+        axiosMock.onGet("/api/shift").reply(200, info);
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                   <ShiftInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText("Id: 1")).toBeInTheDocument();
+            expect(screen.getByText("Day: Monday")).toBeInTheDocument();
+            expect(screen.getByText("Start: 3:30PM")).toBeInTheDocument();
+            expect(screen.getByText("End: 4:00PM")).toBeInTheDocument();
+            expect(screen.getByText("Driver Id: 3")).toBeInTheDocument();
+            expect(screen.getByText("Driver Backup Id: 4")).toBeInTheDocument();
+        });
+
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -70,6 +70,20 @@ public class RideController extends ApiController {
         return ride;
     }
 
+    @Operation(summary = "Get all rides by shiftId")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
+    @GetMapping("/shiftId")
+    public Iterable<Ride> allRidesByShiftId(
+            @Parameter(name="shiftId", description = "long, shiftId of the Ride to get", 
+            required = true)  
+            @RequestParam Long shiftId) {
+        Iterable<Ride> rides;
+
+        rides = rideRepository.findAllByShiftId(shiftId);
+
+        return rides;
+    }
+
     @Operation(summary = "Create a new ride")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
@@ -176,6 +190,27 @@ public class RideController extends ApiController {
         ride.setDropoffRoom(incoming.getDropoffRoom());
         ride.setCourse(incoming.getCourse());
         ride.setNotes(incoming.getNotes());
+
+        rideRepository.save(ride);
+
+        return ride;
+    }
+
+    @Operation(summary = "Admins can assign a driver to a ride")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/assigndriver")
+    public Ride assigndriverRide(
+            @Parameter(name="id", description="long, Id of the Ride to be edited", 
+            required = true)
+            @RequestParam Long id,
+            @RequestBody @Valid Ride incoming) {
+
+        Ride ride;
+
+        ride = rideRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
+
+        ride.setShiftId(incoming.getShiftId());
 
         rideRepository.save(ride);
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Ride.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Ride.java
@@ -33,10 +33,13 @@ public class Ride {
   private String endTime; // format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
 
   private String pickupBuilding;
-  private String dropoffBuilding;
+  private String dropoffBuilding; 
   
   private String dropoffRoom;
   private String pickupRoom;
   private String notes;
   private String course; // e.g. CMPSC 156
+
+  @Builder.Default
+  private long shiftId = 0;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/RideRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/RideRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface RideRepository extends CrudRepository<Ride, Long> {
   Iterable<Ride> findAllByRiderId(long riderId);
   Optional<Ride> findByIdAndRiderId(long id, long riderId);
+  Iterable<Ride> findAllByShiftId(long shiftId);
 }


### PR DESCRIPTION
Added functionality where Admins can assign a shiftId to Ride Requests.

For the backend:  
- rideRequests now have a parameter called "shiftId" which is defaulted to "0" when a rideRequest is created
- Added a method to get all rides by shiftId at the endpoint shift/shiftId
- Added suitable tests

For the frontend:
- Added a new component called "ShiftInfo" which displays info about a shift
- Added a new page called "ShiftInfoPage" which displays information about a shift (ShiftInfo) as well as a table of all the RideRequests assigned to it (i.e. has a matching shiftId).
-  Added "Info" button to ShiftTable which displays the ShiftInfoPage of the corresponding shift.
- Added "shiftId" column to the RideReuqestTable which displays assigned shiftId. This is a hyperlink to ShiftInfoPage of the corresponding shift.
- Added "Assign" button to the RideRequestTable for admins which directs to the RideRequestAssignPage.
- Added RideRequestAssignPage which allows admins to assign a shiftId to a rideReqest.
- Added suitable tests & stories

Closes #36 