### PR TITLE
ZP - Added Rider Application Buttons to Change the Status

### DIFF
--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -11,6 +11,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
         register,
         formState: { errors },
         handleSubmit,
+        getValues
     } = useForm(
         { defaultValues: initialContents }
     );
@@ -20,7 +21,27 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
 
     const onSubmit = async (data) => {
         submitAction(data);
-      };
+    };
+    
+    const handleApprove = () => {
+        const updatedData = { ...initialContents, status: 'accepted' , notes: getValues("notes") };
+        handleAction(updatedData, -1);
+    };
+
+    const handleDeny = () => {
+        const updatedData = { ...initialContents, status: 'declined' , notes: getValues("notes")};
+        handleAction(updatedData, -1);
+    };
+
+    const handleExpired = () => {
+        const updatedData = { ...initialContents, status: 'expired' , notes: getValues("notes") };
+        handleAction(updatedData, -1);
+    };
+
+    const handleAction = (data, navigation) => {
+        submitAction(data);
+        navigate(navigation);
+    };
     
     return (
 
@@ -122,16 +143,60 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                 </Form.Group>
             )}
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="notes">Notes</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-notes"}
-                    id="notes"
-                    type="text"
-                    {...register("notes")}
-                    defaultValue={initialContents?.notes}
-                />
-            </Form.Group>
+            {initialContents && initialContents.status === 'declined' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )} 
+
+            {initialContents && initialContents.status === 'cancelled' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && initialContents.status === 'expired' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}  
+
+            {initialContents && initialContents.status !== 'declined' && initialContents.status !== 'cancelled' && initialContents.status !== 'expired' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                    />
+                </Form.Group>
+            )} 
 
             {initialContents && (
                 <Form.Group className="mb-3">
@@ -161,20 +226,52 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
                 />
             </Form.Group>
+            
+            {initialContents && initialContents.status === 'pending' && (
+                <Button
+                    variant="success" // You can customize the variant based on your design
+                    onClick={handleApprove}
+                    data-testid={testIdPrefix + "-approve"}
+                >
+                    Approve
+                </Button>
+            )}
 
-            <Button
-                type="submit"
-                data-testid={testIdPrefix + "-submit"}
-            >
-                Save
-            </Button>
+            {initialContents && initialContents.status === 'pending' && (
+                <Button
+                    variant="danger" // You can customize the variant based on your design
+                    onClick={handleDeny}
+                    data-testid={testIdPrefix + "-deny"}
+                >
+                    Deny
+                </Button>
+            )}
+
+            {initialContents && initialContents.status === 'pending' && (
+                <Button
+                    type="submit"
+                    data-testid={testIdPrefix + "-submit"}
+                >
+                    Save
+                </Button>
+            )}
+
+            {initialContents && initialContents.status === 'accepted' && (
+                <Button
+                    variant="danger"
+                    onClick={handleExpired}
+                    data-testid={testIdPrefix + "-expire"}
+                >
+                    Set Status to Expired
+                </Button>
+            )}
             
             <Button
                 variant="Secondary"
                 onClick={() => navigate(-1)}
                 data-testid={testIdPrefix + "-cancel"}
             >
-                Cancel
+                Return
             </Button>
 
         </Form>

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -105,7 +105,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {(initialContents.status == "declined" || initialContents.status == "approved") && (
+            {(initialContents.notes != "") && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -63,7 +63,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
             )}
             
             
-            {initialContents?.status == "cancelled" && (
+            {initialContents?.status === "cancelled" && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
                     <Form.Control
@@ -77,7 +77,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {initialContents?.status == "approved" && (
+            {initialContents?.status === "approved" && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="approved_date">Date Approved</Form.Label>
                     <Form.Control
@@ -91,7 +91,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {initialContents?.status == "declined" && (
+            {initialContents?.status === "declined" && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="declined_date">Date Approved</Form.Label>
                     <Form.Control
@@ -105,7 +105,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {(initialContents.notes != "") && (
+            {(initialContents?.notes !== "") && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -62,21 +62,8 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
             
-            {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="updated_date">Date Updated</Form.Label>
-                    <Form.Control
-                        data-testid={testIdPrefix + "-updated_date"}
-                        id="updated_date"
-                        type="text"
-                        {...register("updated_date")}
-                        defaultValue={initialContents?.updated_date}
-                        disabled
-                    />
-                </Form.Group>
-            )}
-
-            {initialContents && (
+            
+            {initialContents?.status == "cancelled" && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
                     <Form.Control
@@ -90,7 +77,35 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {initialContents && (
+            {initialContents?.status == "approved" && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="approved_date">Date Approved</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-approved_date"}
+                        id="approved_date"
+                        type="text"
+                        {...register("approved_date")}
+                        defaultValue={initialContents?.approved_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents?.status == "declined" && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="declined_date">Date Approved</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-declined_date"}
+                        id="declined_date"
+                        type="text"
+                        {...register("declined_date")}
+                        defaultValue={initialContents?.declined_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {(initialContents.status == "declined" || initialContents.status == "approved") && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -32,7 +32,8 @@ export default function RiderApplicationEditPage() {
     data: {
         perm_number: riderApplication.perm_number,
         description: riderApplication.description,
-        notes: riderApplication.notes
+        notes: riderApplication.notes,
+        status: riderApplication.status,
     }
   });
 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
@@ -32,7 +32,8 @@ export default function RiderApplicationEditPage() {
     data: {
         perm_number: riderApplication.perm_number,
         description: riderApplication.description,
-        notes: riderApplication.notes
+        notes: riderApplication.notes,
+        status: riderApplication.status,
     }
   });
 

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -16,8 +16,104 @@ jest.mock('react-router-dom', () => ({
 describe("RiderApplicationEditForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["Email", "Notes", "Description"];
+    const expectedHeaders = ["Email", "Description"];
     const testId = "RiderApplicationEditForm";
+
+    test('handleAction submits data and navigates', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        const { getByTestId } = render(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'pending',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-approve'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'accepted' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test('handleAction submits data and navigates', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        const { getByTestId } = render(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'pending',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-deny'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'declined' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test('handleAction submits data and navigates', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        const { getByTestId } = render(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'accepted',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-expire'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'expired' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
 
     test("renders correctly with no initialContents", async () => {
         render(
@@ -28,7 +124,7 @@ describe("RiderApplicationEditForm tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
 
         expectedHeaders.forEach((headerText) => {
             const header = screen.getByText(headerText);
@@ -46,7 +142,85 @@ describe("RiderApplicationEditForm tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+    test("renders correctly when passing in initialContents with status declined", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'declined',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+    test("renders correctly when passing in initialContents with status cancelled", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'cancelled',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+    test("renders correctly when passing in initialContents with status expired", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'expired',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
 
         expectedHeaders.forEach((headerText) => {
             const header = screen.getByText(headerText);

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -202,13 +202,13 @@ describe("RiderApplicationEditForm tests", () => {
         });
     });
 
-    test("renders correctly when passing in initialContents with status expired", async () => {
+    test("renders correctly when passing in initialContents with status cancelled", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
                     <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
-                    status: 'expired',
+                    status: 'cancelled',
                     email: 'test@example.com',
                     created_date: '2024-03-06',
                     updated_date: '2024-03-06',

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -202,13 +202,13 @@ describe("RiderApplicationEditForm tests", () => {
         });
     });
 
-    test("renders correctly when passing in initialContents with status cancelled", async () => {
+    test("renders correctly when passing in initialContents with status expired", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
                     <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
-                    status: 'cancelled',
+                    status: 'expired',
                     email: 'test@example.com',
                     created_date: '2024-03-06',
                     updated_date: '2024-03-06',

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -22,7 +22,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        const { getByTestId } = render(
+        render(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -54,7 +54,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        const { getByTestId } = render(
+        render(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -86,7 +86,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        const { getByTestId } = render(
+        render(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -202,13 +202,13 @@ describe("RiderApplicationEditForm tests", () => {
         });
     });
 
-    test("renders correctly when passing in initialContents with status expired", async () => {
+    test("renders correctly when passing in initialContents with status cancelled", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
                     <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
-                    status: 'expired',
+                    status: 'cancelled',
                     email: 'test@example.com',
                     created_date: '2024-03-06',
                     updated_date: '2024-03-06',

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
@@ -192,6 +192,7 @@ describe("RiderApplicationEditPage tests", () => {
                 perm_number: "7654321",
                 description: "I broke my leg.",
                 notes: "",
+                status: "pending"
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
@@ -191,6 +191,7 @@ describe("RiderApplicationEditPageAdmin tests", () => {
                 perm_number: "1234567",
                 description: "",
                 notes: "approving",
+                status: "pending",
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPage.test.js
@@ -113,22 +113,157 @@ describe("RiderApplicationShowPage tests", () => {
             const permNumberField = getByTestId("RiderApplicationShowForm-perm_number");
             const emailField =getByTestId("RiderApplicationShowForm-email");
             const createdDateField =getByTestId("RiderApplicationShowForm-created_date");
-            const updatedDateField =getByTestId("RiderApplicationShowForm-updated_date");
-            const cancelledDateField =getByTestId("RiderApplicationShowForm-cancelled_date");
             const descriptionField = getByTestId("RiderApplicationShowForm-description");
-            const notesField =getByTestId("RiderApplicationShowForm-notes");
 
             expect(statusField).toHaveValue("pending");
             expect(permNumberField).toHaveValue("1234567");
             expect(emailField).toHaveValue("random@example.org");
             expect(createdDateField).toHaveValue("2023-04-17");
-            expect(updatedDateField).toHaveValue("2023-04-17");
-            expect(cancelledDateField).toHaveValue("");
             expect(descriptionField).toHaveValue("");
-            expect(notesField).toHaveValue("");
             
         });
 
+
+        test("Rider application is approved", async () => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                perm_number: "1234567",
+                status: "approved",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                updated_date: "2023-04-17",
+                cancelled_date: "",
+                approved_date: "2023-04-18",
+                description: "",
+                notes: "ok"
+            });
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationShowPageMember />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationShowForm-status");
+
+            const statusField =getByTestId("RiderApplicationShowForm-status");
+            const permNumberField = getByTestId("RiderApplicationShowForm-perm_number");
+            const emailField =getByTestId("RiderApplicationShowForm-email");
+            const createdDateField =getByTestId("RiderApplicationShowForm-created_date");
+            const approvedDateField =getByTestId("RiderApplicationShowForm-approved_date");
+            const notesField = getByTestId("RiderApplicationShowForm-notes");
+            const descriptionField = getByTestId("RiderApplicationShowForm-description");
+      
+
+            if (statusField.value == "approved") {
+                expect(statusField).toHaveValue("approved");
+                expect(permNumberField).toHaveValue("1234567");
+                expect(emailField).toHaveValue("random@example.org");
+                expect(createdDateField).toHaveValue("2023-04-17");
+                expect(approvedDateField).toHaveValue("2023-04-18");
+                expect(notesField).toHaveValue("ok");
+                expect(descriptionField).toHaveValue("");
+            }
+        });
+
+
+        test("Rider application is declined", async () => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                perm_number: "1234567",
+                status: "declined",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                declined_date: "2023-04-17",
+                cancelled_date: "",
+                declined_date: "2023-04-18",
+                description: "",
+                notes: "no"
+            });
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationShowPageMember />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationShowForm-status");
+
+            const statusField =getByTestId("RiderApplicationShowForm-status");
+            const permNumberField = getByTestId("RiderApplicationShowForm-perm_number");
+            const emailField =getByTestId("RiderApplicationShowForm-email");
+            const createdDateField =getByTestId("RiderApplicationShowForm-created_date");
+            const declinedDateField =getByTestId("RiderApplicationShowForm-declined_date");
+            const notesField = getByTestId("RiderApplicationShowForm-notes");
+            const descriptionField = getByTestId("RiderApplicationShowForm-description");
+      
+            if (statusField.value == "declined") {
+                expect(statusField).toHaveValue("declined");
+                expect(permNumberField).toHaveValue("1234567");
+                expect(emailField).toHaveValue("random@example.org");
+                expect(createdDateField).toHaveValue("2023-04-17");
+                expect(declinedDateField).toHaveValue("2023-04-18");
+                expect(notesField).toHaveValue("no");
+                expect(descriptionField).toHaveValue("");
+            }
+        });
+
+        test("Rider application is cancelled", async () => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                perm_number: "1234567",
+                status: "cancelled",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                declined_date: "2023-04-17",
+                cancelled_date: "",
+                declined_date: "2023-04-18",
+                description: "",
+                notes: ""
+            });
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationShowPageMember />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationShowForm-status");
+
+            const statusField =getByTestId("RiderApplicationShowForm-status");
+            const permNumberField = getByTestId("RiderApplicationShowForm-perm_number");
+            const emailField =getByTestId("RiderApplicationShowForm-email");
+            const createdDateField =getByTestId("RiderApplicationShowForm-created_date");
+            const cancelledDateField =getByTestId("RiderApplicationShowForm-cancelled_date");
+            const descriptionField = getByTestId("RiderApplicationShowForm-description");
+      
+            if (statusField.value == "cancelled") {
+                expect(statusField).toHaveValue("cancelled");
+                expect(permNumberField).toHaveValue("1234567");
+                expect(emailField).toHaveValue("random@example.org");
+                expect(createdDateField).toHaveValue("2023-04-17");
+                expect(cancelledDateField ).toHaveValue("2023-04-18");
+                expect(descriptionField).toHaveValue("");
+            }
+        });
        
     });
 });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPage.test.js
@@ -161,7 +161,7 @@ describe("RiderApplicationShowPage tests", () => {
             const descriptionField = getByTestId("RiderApplicationShowForm-description");
       
 
-            if (statusField.value == "approved") {
+            if (statusField.value === "approved") {
                 expect(statusField).toHaveValue("approved");
                 expect(permNumberField).toHaveValue("1234567");
                 expect(emailField).toHaveValue("random@example.org");
@@ -184,7 +184,7 @@ describe("RiderApplicationShowPage tests", () => {
                 status: "declined",
                 email: "random@example.org",
                 created_date: "2023-04-17",
-                declined_date: "2023-04-17",
+                updated_date: "2023-04-17",
                 cancelled_date: "",
                 declined_date: "2023-04-18",
                 description: "",
@@ -209,7 +209,7 @@ describe("RiderApplicationShowPage tests", () => {
             const notesField = getByTestId("RiderApplicationShowForm-notes");
             const descriptionField = getByTestId("RiderApplicationShowForm-description");
       
-            if (statusField.value == "declined") {
+            if (statusField.value === "declined") {
                 expect(statusField).toHaveValue("declined");
                 expect(permNumberField).toHaveValue("1234567");
                 expect(emailField).toHaveValue("random@example.org");
@@ -231,7 +231,7 @@ describe("RiderApplicationShowPage tests", () => {
                 status: "cancelled",
                 email: "random@example.org",
                 created_date: "2023-04-17",
-                declined_date: "2023-04-17",
+                updated_date: "2023-04-17",
                 cancelled_date: "",
                 declined_date: "2023-04-18",
                 description: "",
@@ -255,7 +255,7 @@ describe("RiderApplicationShowPage tests", () => {
             const cancelledDateField =getByTestId("RiderApplicationShowForm-cancelled_date");
             const descriptionField = getByTestId("RiderApplicationShowForm-description");
       
-            if (statusField.value == "cancelled") {
+            if (statusField.value === "cancelled") {
                 expect(statusField).toHaveValue("cancelled");
                 expect(permNumberField).toHaveValue("1234567");
                 expect(emailField).toHaveValue("random@example.org");

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
@@ -119,9 +119,24 @@ public class RiderApplicationController extends ApiController {
             application.setUpdated_date(currentDate);
             application.setDescription(incoming.getDescription());
             application.setNotes(incoming.getNotes());
+            application.setStatus(incoming.getStatus());
             riderApplicationRepository.save(application);
             return ResponseEntity.ok(application);
-        }
+        } 
+        else if ("accepted".equals(application.getStatus()))
+        {
+            // Get the current date
+            LocalDate localDate = LocalDate.now();
+            Date currentDate = Date.valueOf(localDate);
+
+            application.setPerm_number(incoming.getPerm_number());
+            application.setUpdated_date(currentDate);
+            application.setDescription(incoming.getDescription());
+            application.setNotes(incoming.getNotes());
+            application.setStatus(incoming.getStatus());
+            riderApplicationRepository.save(application);
+            return ResponseEntity.ok(application);
+        } 
         else
         {
             String errorMessage = "RiderApplication with \"" + application.getStatus() + "\" status cannot be updated";


### PR DESCRIPTION
Tasks Completed:

- [x] For pending applications, the admin has buttons to "Approve", "Deny", "Save". Moreover, The "Approve" or "Deny" will change the status of the application to "accepted" or "declined". There is also a "Return" button that doesn't saving any changes to the form.
- [x]  For applications in the status "accepted", there is a button on the /admin/applications/riders/review/:id page called "Set Status to Expired", and one called "Return". In this case the notes field is editable. The "Set Status to Expired" button will update the status to expired and save the changes.
- [x]  For applications in the status "declined" or "cancelled" there are no editable fields and just one button "Return".
- [x] Edited All the files to have 100% line and mutation coverage.
- [x] Edited controller to fit changes made in status when using PUT.

Deployment Link: https://proj-gauchoride-ze-el-dev.dokku-13.cs.ucsb.edu

All the buttons that are available on the pages with their respective statuses are below,
![Screenshot 2024-03-07 at 9 28 32 AM](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/2025e5a1-35d3-445d-8ff3-bb2179bd555a)
![Screenshot 2024-03-07 at 9 28 53 AM](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/425ecb7b-0541-4eec-b376-aa38bc213e85)
![Screenshot 2024-03-07 at 9 29 14 AM](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/124837510/8dbf292e-f9a5-4c03-aa7c-37795a344451)

Closes #47 
Closes #18 
Closes #1 