### PR TITLE
Limit the displayed element in the ShowRiderApplyPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,10 +21,10 @@ import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
 
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
-import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
-import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
 import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
+import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -84,6 +84,7 @@ function App() {
         {
           (hasRole(currentUser, "ROLE_DRIVER") ) && <Route exact path="/drivershifts" element={<DriverDashboardPage />} />
         }
+        {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider" element={<RiderApplicationIndexPageMember />} />
         }
         {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,9 @@ import DriverDashboardPage from "main/pages/Drivers/DriverDashboardPage";
 
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
+import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
 import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApplicationShowPageMember";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
@@ -92,10 +94,10 @@ function App() {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/new" element={<RiderApplicationCreatePage />} />
         }
         {
-          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageMember />} />
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageAdmin />} />
         }
         {
-          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders/review/:id" element={<RiderApplicationEditPageMember />} />
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/applications/riders/review/:id" element={<RiderApplicationEditPageAdmin />} />
         }
         {
           (hasRole(currentUser, "ROLE_MEMBER")) && <Route exact path="/apply/rider/edit/:id" element={<RiderApplicationEditPageMember />} />

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -77,6 +77,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_ADMIN") && (
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item as={Link} to="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/admin/applications/riders">Rider Applications</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -1,0 +1,203 @@
+import React from 'react'
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Apply", email}) {
+    const navigate = useNavigate();
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents }
+    );
+    // Stryker enable all
+   
+    const testIdPrefix = "RiderApplicationForm";
+
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Application Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        defaultValue={initialContents?.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="userId">Applicant Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-userId"}
+                        id="userId"
+                        type="text"
+                        {...register("userId")}
+                        defaultValue={initialContents?.userId}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="status">Status</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-status"}
+                        id="status"
+                        type="text"
+                        {...register("status")}
+                        defaultValue={initialContents?.status}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="email">Email</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-email"}
+                    id="email"
+                    type="text"
+                    {...register("email")}
+                    defaultValue={email}
+                    disabled
+                />
+            </Form.Group>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="created_date">Date Applied</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-created_date"}
+                        id="created_date"
+                        type="text"
+                        {...register("created_date")}
+                        defaultValue={initialContents?.created_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+            
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="updated_date">Date Updated</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-updated_date"}
+                        id="updated_date"
+                        type="text"
+                        {...register("updated_date")}
+                        defaultValue={initialContents?.updated_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-cancelled_date"}
+                        id="cancelled_date"
+                        type="text"
+                        {...register("cancelled_date")}
+                        defaultValue={initialContents?.cancelled_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-perm_number"}
+                    id="perm_number"
+                    type="text"
+                    isInvalid={Boolean(errors.perm_number)}
+                    {...register("perm_number", {
+                        required: "Perm Number is required.",
+                        minLength: {
+                            value: 7,
+                            message: "Perm Number must be exactly 7 characters long."
+                        },
+                        maxLength: {
+                            value: 7,
+                            message: "Perm Number must be exactly 7 characters long."
+                        }
+                    })}
+                    placeholder="e.g. 0000000"
+                    defaultValue={initialContents?.perm_number}
+                    disabled
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.perm_number?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="description">Description</Form.Label>
+                <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>                        
+                <Form.Control
+                    data-testid={testIdPrefix + "-description"}
+                    id="description"
+                    as="textarea"
+                    isInvalid={Boolean(errors.description)}
+                    {...register("description", {
+                        required: "Description is required."
+                    })}
+                    placeholder="e.g. My legs are broken."  
+                    defaultValue={initialContents?.description}
+                    disabled
+                    style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.description?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default RiderApplicationForm;

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -11,6 +11,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
         register,
         formState: { errors },
         handleSubmit,
+        getValues
     } = useForm(
         { defaultValues: initialContents }
     );
@@ -20,7 +21,27 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
 
     const onSubmit = async (data) => {
         submitAction(data);
-      };
+    };
+    
+    const handleApprove = () => {
+        const updatedData = { ...initialContents, status: 'accepted' , notes: getValues("notes") };
+        handleAction(updatedData, -1);
+    };
+
+    const handleDeny = () => {
+        const updatedData = { ...initialContents, status: 'declined' , notes: getValues("notes")};
+        handleAction(updatedData, -1);
+    };
+
+    const handleExpired = () => {
+        const updatedData = { ...initialContents, status: 'expired' , notes: getValues("notes") };
+        handleAction(updatedData, -1);
+    };
+
+    const handleAction = (data, navigation) => {
+        submitAction(data);
+        navigate(navigation);
+    };
     
     return (
 
@@ -122,16 +143,60 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                 </Form.Group>
             )}
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="notes">Notes</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-notes"}
-                    id="notes"
-                    type="text"
-                    {...register("notes")}
-                    defaultValue={initialContents?.notes}
-                />
-            </Form.Group>
+            {initialContents && initialContents.status === 'declined' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )} 
+
+            {initialContents && initialContents.status === 'cancelled' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents && initialContents.status === 'expired' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}  
+
+            {initialContents && initialContents.status !== 'declined' && initialContents.status !== 'cancelled' && initialContents.status !== 'expired' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                    />
+                </Form.Group>
+            )} 
 
             {initialContents && (
                 <Form.Group className="mb-3">
@@ -161,20 +226,52 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
                 />
             </Form.Group>
+            
+            {initialContents && initialContents.status === 'pending' && (
+                <Button
+                    variant="success" // You can customize the variant based on your design
+                    onClick={handleApprove}
+                    data-testid={testIdPrefix + "-approve"}
+                >
+                    Approve
+                </Button>
+            )}
 
-            <Button
-                type="submit"
-                data-testid={testIdPrefix + "-submit"}
-            >
-                Save
-            </Button>
+            {initialContents && initialContents.status === 'pending' && (
+                <Button
+                    variant="danger" // You can customize the variant based on your design
+                    onClick={handleDeny}
+                    data-testid={testIdPrefix + "-deny"}
+                >
+                    Deny
+                </Button>
+            )}
+
+            {initialContents && initialContents.status === 'pending' && (
+                <Button
+                    type="submit"
+                    data-testid={testIdPrefix + "-submit"}
+                >
+                    Save
+                </Button>
+            )}
+
+            {initialContents && initialContents.status === 'accepted' && (
+                <Button
+                    variant="danger"
+                    onClick={handleExpired}
+                    data-testid={testIdPrefix + "-expire"}
+                >
+                    Set Status to Expired
+                </Button>
+            )}
             
             <Button
                 variant="Secondary"
                 onClick={() => navigate(-1)}
                 data-testid={testIdPrefix + "-cancel"}
             >
-                Cancel
+                Return
             </Button>
 
         </Form>

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -3,7 +3,7 @@ import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
 
-function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Apply", email}) {
+function RiderApplicationEditForm({ initialContents, submitAction, email}) {
     const navigate = useNavigate();
     
     // Stryker disable all
@@ -16,12 +16,15 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
     );
     // Stryker enable all
    
-    const testIdPrefix = "RiderApplicationForm";
+    const testIdPrefix = "RiderApplicationEditForm";
 
-
+    const onSubmit = async (data) => {
+        submitAction(data);
+      };
+    
     return (
 
-        <Form onSubmit={handleSubmit(submitAction)}>
+        <Form onSubmit={handleSubmit(onSubmit)}>
 
             {initialContents && (
                 <Form.Group className="mb-3" >
@@ -119,45 +122,30 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
                 </Form.Group>
             )}
 
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="notes">Notes</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-notes"}
+                    id="notes"
+                    type="text"
+                    {...register("notes")}
+                    defaultValue={initialContents?.notes}
+                />
+            </Form.Group>
+
             {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                <Form.Group className="mb-3">
+                    <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
                     <Form.Control
-                        data-testid={testIdPrefix + "-notes"}
-                        id="notes"
+                        data-testid={testIdPrefix + "-perm_number"}
+                        id="perm_number"
                         type="text"
-                        {...register("notes")}
-                        defaultValue={initialContents?.notes}
+                        {...register("perm_number")}
+                        defaultValue={initialContents?.perm_number}
+                        disabled
                     />
                 </Form.Group>
             )}
-
-            <Form.Group className="mb-3">
-                <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-perm_number"}
-                    id="perm_number"
-                    type="text"
-                    isInvalid={Boolean(errors.perm_number)}
-                    {...register("perm_number", {
-                        required: "Perm Number is required.",
-                        minLength: {
-                            value: 7,
-                            message: "Perm Number must be exactly 7 characters long."
-                        },
-                        maxLength: {
-                            value: 7,
-                            message: "Perm Number must be exactly 7 characters long."
-                        }
-                    })}
-                    placeholder="e.g. 0000000"
-                    defaultValue={initialContents?.perm_number}
-                    disabled
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.perm_number?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="description">Description</Form.Label>
@@ -167,24 +155,18 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
                     id="description"
                     as="textarea"
                     isInvalid={Boolean(errors.description)}
-                    {...register("description", {
-                        required: "Description is required."
-                    })}
-                    placeholder="e.g. My legs are broken."  
+                    {...register("description")}
                     defaultValue={initialContents?.description}
                     disabled
                     style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
                 />
-                <Form.Control.Feedback type="invalid">
-                    {errors.description?.message}
-                </Form.Control.Feedback>
             </Form.Group>
 
             <Button
                 type="submit"
                 data-testid={testIdPrefix + "-submit"}
             >
-                {buttonLabel}
+                Save
             </Button>
             
             <Button
@@ -200,4 +182,4 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
     )
 }
 
-export default RiderApplicationForm;
+export default RiderApplicationEditForm;

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -76,7 +76,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
             
-            {initialContents?.status == "cancelled" && (
+            {initialContents?.status === "cancelled" && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
                     <Form.Control
@@ -90,7 +90,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {initialContents?.status == 'accepted' && (
+            {initialContents?.status === 'accepted' && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="accepted_date">Date Accepted</Form.Label>
                     <Form.Control
@@ -104,7 +104,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {initialContents?.status == 'declined' && (
+            {initialContents?.status === 'declined' && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="declined_date">Date Declined</Form.Label>
                     <Form.Control
@@ -118,7 +118,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {(initialContents?.notes != "") && (
+            {(initialContents?.notes !== "") && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -92,7 +92,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
 
             {initialContents?.status == 'accepted' && (
                 <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="approved_date">Date Approved</Form.Label>
+                    <Form.Label htmlFor="approved_date">Date Accepted</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-approved_date"}
                         id="approved_date"

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -62,9 +62,9 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
             
-            {initialContents && (
+            {initialContents?.status === "pending" && initialContents?.notes !== '' && (
                 <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="updated_date">Date Updated</Form.Label>
+                    <Form.Label htmlFor="updated_date"> Date Updated</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-updated_date"}
                         id="updated_date"
@@ -75,8 +75,8 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                     />
                 </Form.Group>
             )}
-
-            {initialContents && (
+            
+            {initialContents?.status == "cancelled" && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
                     <Form.Control
@@ -90,7 +90,35 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
                 </Form.Group>
             )}
 
-            {initialContents && (
+            {initialContents?.status == 'accepted' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="approved_date">Date Approved</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-approved_date"}
+                        id="approved_date"
+                        type="text"
+                        {...register("approved_date")}
+                        defaultValue={initialContents?.updated_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {initialContents?.status == 'declined' && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="declined_date">Date Declined</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-declined_date"}
+                        id="declined_date"
+                        type="text"
+                        {...register("declined_date")}
+                        defaultValue={initialContents?.updated_date}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            {(initialContents?.notes != "") && (
                 <Form.Group className="mb-3" >
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -92,12 +92,12 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
 
             {initialContents?.status == 'accepted' && (
                 <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="approved_date">Date Accepted</Form.Label>
+                    <Form.Label htmlFor="accepted_date">Date Accepted</Form.Label>
                     <Form.Control
-                        data-testid={testIdPrefix + "-approved_date"}
-                        id="approved_date"
+                        data-testid={testIdPrefix + "-accepted_date"}
+                        id="accepted_date"
                         type="text"
-                        {...register("approved_date")}
+                        {...register("accepted_date")}
                         defaultValue={initialContents?.updated_date}
                         disabled
                     />

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -30,6 +30,8 @@ export default function RiderApplicationEditPage() {
       id: riderApplication.id,
     },
     data: {
+        perm_number: riderApplication.perm_number,
+        description: riderApplication.description,
         notes: riderApplication.notes
     }
   });
@@ -52,7 +54,7 @@ export default function RiderApplicationEditPage() {
   }
 
   if (isSuccess) {
-    return <Navigate to="/apply/rider" />
+    return <Navigate to="/admin/applications/riders" />
   }
 
     return (
@@ -60,7 +62,7 @@ export default function RiderApplicationEditPage() {
             <div className="pt-2">
                 <h1>Edit Rider Application</h1>
                 {riderApplication &&
-                <RiderApplicationEditForm initialContents={riderApplication} submitAction={onSubmit} buttonLabel="Edit" />
+                <RiderApplicationEditForm initialContents={riderApplication} submitAction={onSubmit} />
                 }
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -32,7 +32,8 @@ export default function RiderApplicationEditPage() {
     data: {
         perm_number: riderApplication.perm_number,
         description: riderApplication.description,
-        notes: riderApplication.notes
+        notes: riderApplication.notes,
+        status: riderApplication.status,
     }
   });
 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -1,0 +1,68 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import RiderApplicationEditForm from "main/components/RiderApplication/RiderApplicationEditForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+
+import { toast } from "react-toastify";
+
+export default function RiderApplicationEditPage() {
+  let { id } = useParams();
+
+  const { data: riderApplication, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/riderApplication?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/riderApplication`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (riderApplication) => ({
+    url: "/api/riderApplication",
+    method: "PUT",
+    params: {
+      id: riderApplication.id,
+    },
+    data: {
+        notes: riderApplication.notes
+    }
+  });
+
+  const onSuccess = (riderApplication) => {
+    toast(`Application Updated - id: ${riderApplication.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/riderApplication?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/apply/rider" />
+  }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit Rider Application</h1>
+                {riderApplication &&
+                <RiderApplicationEditForm initialContents={riderApplication} submitAction={onSubmit} buttonLabel="Edit" />
+                }
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
@@ -32,7 +32,8 @@ export default function RiderApplicationEditPage() {
     data: {
         perm_number: riderApplication.perm_number,
         description: riderApplication.description,
-        notes: riderApplication.notes
+        notes: riderApplication.notes,
+        status: riderApplication.status,
     }
   });
 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageMember.js
@@ -31,7 +31,8 @@ export default function RiderApplicationEditPage() {
     },
     data: {
         perm_number: riderApplication.perm_number,
-        description: riderApplication.description
+        description: riderApplication.description,
+        notes: riderApplication.notes
     }
   });
 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import {useCurrentUser} from 'main/utils/currentUser'
+import RiderApplicationTable from "main/components/RiderApplication/RiderApplicationTable";
+
+export default function RiderApplicationIndexPage() {
+
+    const currentUser = useCurrentUser();
+    // Stryker disable all
+    // Stryker restore all 
+    
+    const { data: riderApplications, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable all : hard to test for query caching
+            ["/api/rider"],
+            { method: "GET", url: "/api/rider" },
+            []
+            // Stryker restore all 
+    ); 
+    
+    const pendingRiderApplications = riderApplications?.filter(application => application.status === "pending");
+    
+    return (
+          <BasicLayout>
+              <div className="pt-2">
+                <h1>Pending Rider Applications</h1>
+                <RiderApplicationTable riderApplications={pendingRiderApplications} currentUser={currentUser} />
+                <h1>All Rider Applications</h1>
+                <RiderApplicationTable riderApplications={riderApplications} currentUser={currentUser} />
+              </div>
+          </BasicLayout>
+      );
+}

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import RiderApplicationEditForm from "main/components/RiderApplication/RiderApplicationEditForm";
+import { riderApplicationFixtures } from "fixtures/riderApplicationFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("RiderApplicationEditForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Email", "Notes", "Description"];
+    const testId = "RiderApplicationEditForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+          });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={riderApplicationFixtures.oneRiderApplication} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+});

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -16,8 +16,104 @@ jest.mock('react-router-dom', () => ({
 describe("RiderApplicationEditForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["Email", "Notes", "Description"];
+    const expectedHeaders = ["Email", "Description"];
     const testId = "RiderApplicationEditForm";
+
+    test('handleAction submits data and navigates', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        const { getByTestId } = render(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'pending',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-approve'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'accepted' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test('handleAction submits data and navigates', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        const { getByTestId } = render(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'pending',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-deny'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'declined' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test('handleAction submits data and navigates', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        const { getByTestId } = render(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'accepted',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-expire'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'expired' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
 
     test("renders correctly with no initialContents", async () => {
         render(
@@ -28,7 +124,7 @@ describe("RiderApplicationEditForm tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
 
         expectedHeaders.forEach((headerText) => {
             const header = screen.getByText(headerText);
@@ -46,7 +142,85 @@ describe("RiderApplicationEditForm tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText(/Save/)).toBeInTheDocument();
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+    test("renders correctly when passing in initialContents with status declined", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'declined',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+    test("renders correctly when passing in initialContents with status cancelled", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'cancelled',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
+    test("renders correctly when passing in initialContents with status expired", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RiderApplicationEditForm initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'expired',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
 
         expectedHeaders.forEach((headerText) => {
             const header = screen.getByText(headerText);

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -202,13 +202,13 @@ describe("RiderApplicationEditForm tests", () => {
         });
     });
 
-    test("renders correctly when passing in initialContents with status cancelled", async () => {
+    test("renders correctly when passing in initialContents with status expired", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
                     <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
-                    status: 'cancelled',
+                    status: 'expired',
                     email: 'test@example.com',
                     created_date: '2024-03-06',
                     updated_date: '2024-03-06',

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -22,7 +22,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        const { getByTestId } = render(
+        render(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -54,7 +54,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        const { getByTestId } = render(
+        render(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -86,7 +86,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        const { getByTestId } = render(
+        render(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -202,13 +202,13 @@ describe("RiderApplicationEditForm tests", () => {
         });
     });
 
-    test("renders correctly when passing in initialContents with status expired", async () => {
+    test("renders correctly when passing in initialContents with status cancelled", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
                     <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
-                    status: 'expired',
+                    status: 'cancelled',
                     email: 'test@example.com',
                     created_date: '2024-03-06',
                     updated_date: '2024-03-06',

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
@@ -191,6 +191,7 @@ describe("RiderApplicationEditPage tests", () => {
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
                 perm_number: "7654321",
                 description: "I broke my leg.",
+                notes: "",
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPage.test.js
@@ -192,6 +192,7 @@ describe("RiderApplicationEditPage tests", () => {
                 perm_number: "7654321",
                 description: "I broke my leg.",
                 notes: "",
+                status: "pending"
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
@@ -1,0 +1,200 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("RiderApplicationEditPageAdmin tests", () => {
+
+    describe("when the backend doesn't return a todo", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.memberOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            const {queryByTestId, findByText} = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await findByText("Edit Rider Application");
+            expect(queryByTestId("RiderApplicationEditForm-id")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                perm_number: "1234567",
+                status: "pending",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                updated_date: "2023-04-17",
+                cancelled_date: "",
+                description: "",
+                notes: ""
+            });
+            axiosMock.onPut('/api/riderApplication').reply(200, {
+                id: 17,
+                perm_number: "7654321",
+                status: "pending",
+                email: "random@example.org",
+                created_date: "2023-04-17",
+                updated_date: "2023-08-25",
+                cancelled_date: "",
+                description: "My leg is broken",
+                notes: ""
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationEditForm-id");
+
+            const statusField =getByTestId("RiderApplicationEditForm-status");
+            const permNumberField = getByTestId("RiderApplicationEditForm-perm_number");
+            const emailField =getByTestId("RiderApplicationEditForm-email");
+            const createdDateField =getByTestId("RiderApplicationEditForm-created_date");
+            const updatedDateField =getByTestId("RiderApplicationEditForm-updated_date");
+            const cancelledDateField =getByTestId("RiderApplicationEditForm-cancelled_date");
+            const descriptionField = getByTestId("RiderApplicationEditForm-description");
+            const notesField =getByTestId("RiderApplicationEditForm-notes");
+
+            expect(statusField).toHaveValue("pending");
+            expect(permNumberField).toHaveValue("1234567");
+            expect(emailField).toHaveValue("random@example.org");
+            expect(createdDateField).toHaveValue("2023-04-17");
+            expect(updatedDateField).toHaveValue("2023-04-17");
+            expect(cancelledDateField).toHaveValue("");
+            expect(descriptionField).toHaveValue("");
+            expect(notesField).toHaveValue("");
+            
+        });
+
+        test("Changes when you click Update", async () => {
+
+                
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RiderApplicationEditPageAdmin />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("RiderApplicationEditForm-id");
+
+            const statusField =getByTestId("RiderApplicationEditForm-status");
+            const permNumberField = getByTestId("RiderApplicationEditForm-perm_number");
+            const emailField =getByTestId("RiderApplicationEditForm-email");
+            const createdDateField =getByTestId("RiderApplicationEditForm-created_date");
+            const updatedDateField =getByTestId("RiderApplicationEditForm-updated_date");
+            const cancelledDateField =getByTestId("RiderApplicationEditForm-cancelled_date");
+            const descriptionField = getByTestId("RiderApplicationEditForm-description");
+            const notesField =getByTestId("RiderApplicationEditForm-notes");
+            const submitButton = getByTestId("RiderApplicationEditForm-submit")
+
+            expect(statusField).toHaveValue("pending");
+            expect(permNumberField).toHaveValue("1234567");
+            expect(emailField).toHaveValue("random@example.org");
+            expect(createdDateField).toHaveValue("2023-04-17");
+            expect(updatedDateField).toHaveValue("2023-04-17");
+            expect(cancelledDateField).toHaveValue("");
+            expect(descriptionField).toHaveValue("");
+            expect(notesField).toHaveValue("");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(notesField, { target: { value: "approving" } });
+
+            fireEvent.click(submitButton);
+
+    
+            await waitFor(() => expect(mockToast).toHaveBeenCalled());
+            expect(mockToast).toBeCalledWith("Application Updated - id: 17");
+            expect(mockNavigate).toBeCalledWith({ "to": "/admin/applications/riders" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                perm_number: "1234567",
+                description: "",
+                notes: "approving",
+            })); // posted object
+
+        });
+
+       
+    });
+});

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
@@ -191,6 +191,7 @@ describe("RiderApplicationEditPageAdmin tests", () => {
                 perm_number: "1234567",
                 description: "",
                 notes: "approving",
+                status: "pending",
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, screen, render, waitFor } from "@testing-library/react";
+import { screen, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
@@ -27,15 +27,6 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     const axiosMock = new AxiosMockAdapter(axios);
 
     const testId = "RiderApplicationTable";
-
-    const applications = [
-        riderApplicationFixtures.threeRiderApplications[0],
-        riderApplicationFixtures.threeRiderApplications[1],
-        {
-            ...riderApplicationFixtures.threeRiderApplications[2],
-            status: "pending"
-        }
-    ]
 
     const setupMemberOnly = () => {
         axiosMock.reset();

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -1,0 +1,144 @@
+import { fireEvent, screen, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { riderApplicationFixtures } from "fixtures/riderApplicationFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("RiderApplicationIndexPageAdmin tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "RiderApplicationTable";
+
+    const applications = [
+        riderApplicationFixtures.threeRiderApplications[0],
+        riderApplicationFixtures.threeRiderApplications[1],
+        {
+            ...riderApplicationFixtures.threeRiderApplications[2],
+            status: "pending"
+        }
+    ]
+
+    const setupMemberOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.memberOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupMemberOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("renders three rides without crashing for regular user", async () => {
+        setupMemberOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+
+    });
+
+    test("renders three rides without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+
+    });
+
+    test("renders empty table when backend unavailable, member only", async () => {
+        setupMemberOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPageAdmin />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPageMember.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationShowPageMember.test.js
@@ -113,19 +113,13 @@ describe("RiderApplicationShowPage tests", () => {
             const permNumberField = getByTestId("RiderApplicationShowForm-perm_number");
             const emailField =getByTestId("RiderApplicationShowForm-email");
             const createdDateField =getByTestId("RiderApplicationShowForm-created_date");
-            const updatedDateField =getByTestId("RiderApplicationShowForm-updated_date");
-            const cancelledDateField =getByTestId("RiderApplicationShowForm-cancelled_date");
             const descriptionField = getByTestId("RiderApplicationShowForm-description");
-            const notesField =getByTestId("RiderApplicationShowForm-notes");
 
             expect(statusField).toHaveValue("pending");
             expect(permNumberField).toHaveValue("1234567");
             expect(emailField).toHaveValue("random@example.org");
             expect(createdDateField).toHaveValue("2023-04-17");
-            expect(updatedDateField).toHaveValue("2023-04-17");
-            expect(cancelledDateField).toHaveValue("");
             expect(descriptionField).toHaveValue("");
-            expect(notesField).toHaveValue("");
             
         });
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
@@ -118,7 +118,7 @@ public class RiderApplicationController extends ApiController {
             application.setPerm_number(incoming.getPerm_number());
             application.setUpdated_date(currentDate);
             application.setDescription(incoming.getDescription());
-
+            application.setNotes(incoming.getNotes());
             riderApplicationRepository.save(application);
             return ResponseEntity.ok(application);
         }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationController.java
@@ -119,9 +119,24 @@ public class RiderApplicationController extends ApiController {
             application.setUpdated_date(currentDate);
             application.setDescription(incoming.getDescription());
             application.setNotes(incoming.getNotes());
+            application.setStatus(incoming.getStatus());
             riderApplicationRepository.save(application);
             return ResponseEntity.ok(application);
-        }
+        } 
+        else if ("accepted".equals(application.getStatus()))
+        {
+            // Get the current date
+            LocalDate localDate = LocalDate.now();
+            Date currentDate = Date.valueOf(localDate);
+
+            application.setPerm_number(incoming.getPerm_number());
+            application.setUpdated_date(currentDate);
+            application.setDescription(incoming.getDescription());
+            application.setNotes(incoming.getNotes());
+            application.setStatus(incoming.getStatus());
+            riderApplicationRepository.save(application);
+            return ResponseEntity.ok(application);
+        } 
         else
         {
             String errorMessage = "RiderApplication with \"" + application.getStatus() + "\" status cannot be updated";

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
@@ -405,7 +405,7 @@ public class RiderApplicationControllerTests extends ControllerTestCase {
                         .updated_date(currentDate)
                         .cancelled_date(null)
                         .description("My legs were broken")
-                        .notes("")
+                        .notes("can be approved if proved")
                         .build();
 
         String requestBody = mapper.writeValueAsString(application_edited);

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RiderApplicationControllerTests.java
@@ -219,7 +219,7 @@ public class RiderApplicationControllerTests extends ControllerTestCase {
 
             when(riderApplicationRepository.save(eq(application1))).thenReturn(application1);
 
-            String postRequesString = "perm_number=7654321&description=My leg is broken";
+            String postRequesString = "perm_number=7654321&description=My leg is broken&notes=";
 
             // act
             MvcResult response = mockMvc.perform(


### PR DESCRIPTION
Limit the displayed element in the ShowRiderApplyPage
[Dev Link](https://proj-gauchoride-daoyi-dev.dokku-13.cs.ucsb.edu/)

In the applyRiderShowPage, 
the Cancelled, Accepted, and Declined Dates are displayed only when the status is Cancelled, Accepted, or Declined respectively. 
The Note is displayed if it is not null.

The status of the application is 'pending'
<img width="1330" alt="Screenshot 2024-03-07 at 13 18 23" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/122643397/389b44c9-e96e-4107-a087-9747abf66c43">

The status of the application is 'accepted'
<img width="1323" alt="Screenshot 2024-03-07 at 13 18 46" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/122643397/3fb38057-44b6-4790-b234-268aa383f7ea">




close [#32](https://github.com/orgs/ucsb-cs156-w24/projects/91/views/1?pane=issue&itemId=54861040)