### PR TITLE
James - Driver Availability Pages, Stories, Tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,9 @@ import RideRequestIndexPage from "main/pages/Ride/RideRequestIndexPage";
 import RideRequestAssignPage from "main/pages/Ride/RideRequestAssignPage";
 import ShiftPage from "main/pages/ShiftPage";
 
+import DriverAvailabilityCreatePage from "main/pages/Drivers/DriverAvailabilityCreatePage";
+import DriverAvailabilityIndexPage from "main/pages/Drivers/DriverAvailabilityIndexPage"
+
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
 import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
 import ShiftIndexPage from "main/pages/Shift/ShiftIndexPage";
@@ -73,6 +76,12 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/chat" element={<ChatPage />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/availability/" element={<DriverAvailabilityIndexPage />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/availability/create" element={<DriverAvailabilityCreatePage />} />
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/shift/list" element={<ShiftPage />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import ShiftPage from "main/pages/ShiftPage";
 
 import DriverAvailabilityCreatePage from "main/pages/Drivers/DriverAvailabilityCreatePage";
 import DriverAvailabilityIndexPage from "main/pages/Drivers/DriverAvailabilityIndexPage"
+import DriverAvailabilityEditPage from "main/pages/Drivers/DriverAvailabilityEditPage"
 
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
 import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
@@ -33,7 +34,7 @@ import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderAppl
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
-import "bootstrap/dist/css/bootstrap.css";
+import "bootstrap/dist/css/bootstrap.css";  
 
 
 function App() {
@@ -82,6 +83,9 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/availability/create" element={<DriverAvailabilityCreatePage />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/availability/edit/:id" element={<DriverAvailabilityEditPage />} />
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/shift/list" element={<ShiftPage />} />

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -89,7 +89,14 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                isParticipant(currentUser) && (
+                !hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
+                  <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
+                    <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              }
+              {
+                hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                     <NavDropdown.Item data-testid="appnavbar-availability-dropdown-availabilities" as={Link} to="/availability/">Availability</NavDropdown.Item>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -92,6 +92,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 isParticipant(currentUser) && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
+                    <NavDropdown.Item data-testid="appnavbar-availability-dropdown-availabilities" as={Link} to="/availability/">Availability</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityCreatePage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityCreatePage.js
@@ -1,0 +1,50 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import DriverAvailabilityForm from "main/components/Driver/DriverAvailabilityForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function DriverAvailabilityCreatePage() {
+
+    const objectToAxiosParams = (availability) => ({
+        url: "/api/driverAvailability/new",
+        method: "POST",
+        params: {
+            driverId: availability.driverId,
+            day: availability.day,
+            startTime: availability.startTime,
+            endTime: availability.endTime,
+            notes: availability.notes
+        }
+    });
+
+    const onSuccess = (availability) => {
+        toast(`New Driver Availability Created - id: ${availability.id}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/driverAvailability"]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess) {
+        return <Navigate to="/availability/" />
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Submit New Driver Availability</h1>
+                <DriverAvailabilityForm submitAction={onSubmit} />
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityEditPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityEditPage.js
@@ -1,0 +1,71 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import DriverAvailabilityForm from 'main/components/Driver/DriverAvailabilityForm';
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function DriverAvailabilityEditPage({storybook = false}) {
+    let { id } = useParams();
+
+    const { data: availability, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/driverAvailability/id?id=${id}`],
+            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/driverAvailability/id`,
+                params: {
+                    id
+                }
+            }
+        );
+
+    const objectToAxiosPutParams = (availability) => ({
+        url: "/api/driverAvailability",
+        method: "PUT",
+        params: {
+            id: availability.id,
+        },
+        data: {
+            driverId: availability.driverId,
+            day: availability.day,
+            startTime: availability.startTime,
+            endTime: availability.endTime,
+            notes: availability.notes
+        }
+    });
+
+    const onSuccess = (availability) => {
+        toast(`DriverAvailability Updated - id: ${availability.id}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/driverAvailability/id?id=${id}`]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/availability" />
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit Driver Availability</h1>
+                {availability &&
+                <DriverAvailabilityForm initialContents={availability} submitAction={onSubmit} buttonLabel="Update" />
+                }
+            </div>
+        </BasicLayout>
+    )
+
+}

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import DriverAvailabilityTable from 'main/components/Driver/DriverAvailabilityTable';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser'
+import { Button } from 'react-bootstrap';
+
+export default function DriverAvailabilityIndexPage() {
+
+    const currentUser = useCurrentUser();
+
+    const { data: availabilities, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable all : hard to test for query caching
+            ["/api/driverAvailability"],
+            { method: "GET", url: "/api/driverAvailability" },
+            []
+            // Stryker restore all 
+        );
+
+    const createButton = () => {
+        if (hasRole(currentUser, "ROLE_DRIVER")) {
+            return (
+                <Button
+                    variant="primary"
+                    href="/availability/create"
+                    style={{ float: "right" }}
+                >
+                    Create Driver Availability
+                </Button>
+            )
+        } 
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                {createButton()}
+                <h1>Driver Availabilities</h1>
+                <DriverAvailabilityTable Availability={availabilities} currentUser={currentUser} />
+            </div>
+        </BasicLayout>
+    );
+}

--- a/frontend/src/stories/pages/Driver/DriverAvailabilityCreatePage.stories.js
+++ b/frontend/src/stories/pages/Driver/DriverAvailabilityCreatePage.stories.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import RideRequestCreatePage from 'main/pages/Ride/DriverAvailabilityCreatePage';
+import DriverAvailabilityCreatePage from 'main/pages/Drivers/DriverAvailabilityCreatePage';
 
 export default {
     title: 'pages/Driver/DriverAvailabilityCreatePage',
-    component: RideRequestCreatePage
+    component: DriverAvailabilityCreatePage
 };
 
 const Template = () => <DriverAvailabilityCreatePage />;

--- a/frontend/src/stories/pages/Driver/DriverAvailabilityCreatePage.stories.js
+++ b/frontend/src/stories/pages/Driver/DriverAvailabilityCreatePage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import RideRequestCreatePage from 'main/pages/Ride/DriverAvailabilityCreatePage';
+
+export default {
+    title: 'pages/Driver/DriverAvailabilityCreatePage',
+    component: RideRequestCreatePage
+};
+
+const Template = () => <DriverAvailabilityCreatePage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/Driver/DriverAvailabilityEditPage.stories.js
+++ b/frontend/src/stories/pages/Driver/DriverAvailabilityEditPage.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import DriverAvailabilityEditPage from 'main/pages/Ride/DriverAvailabilityEditPage';
+import driverAvailabilityFixtures from 'fixtures/driverAvailabilityFixtures';
+
+export default {
+    title: 'pages/Driver/DriverAvailabilityEditPage',
+    component: DriverAvailabilityEditPage
+};
+
+const Template = () => <DriverAvailabilityEditPage />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+    initialContents: driverAvailabilityFixtures.oneAvailability
+};
+
+
+
+

--- a/frontend/src/stories/pages/Driver/DriverAvailabilityEditPage.stories.js
+++ b/frontend/src/stories/pages/Driver/DriverAvailabilityEditPage.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import DriverAvailabilityEditPage from 'main/pages/Ride/DriverAvailabilityEditPage';
+import DriverAvailabilityEditPage from 'main/pages/Drivers/DriverAvailabilityEditPage';
 import driverAvailabilityFixtures from 'fixtures/driverAvailabilityFixtures';
 
 export default {

--- a/frontend/src/stories/pages/Driver/DriverAvailabilityIndexPage.stories.js
+++ b/frontend/src/stories/pages/Driver/DriverAvailabilityIndexPage.stories.js
@@ -1,0 +1,13 @@
+
+import React from 'react';
+
+import DriverAvailabilityIndexPage from 'main/pages/Ride/DriverAvailabilityIndexPage';
+
+export default {
+    title: 'pages/Driver/DriverAvailabilityIndexPage',
+    component: DriverAvailabilityIndexPage
+};
+
+const Template = () => <DriverAvailabilityIndexPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/Driver/DriverAvailabilityIndexPage.stories.js
+++ b/frontend/src/stories/pages/Driver/DriverAvailabilityIndexPage.stories.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 
-import DriverAvailabilityIndexPage from 'main/pages/Ride/DriverAvailabilityIndexPage';
+import DriverAvailabilityIndexPage from 'main/pages/Drivers/DriverAvailabilityIndexPage';
 
 export default {
     title: 'pages/Driver/DriverAvailabilityIndexPage',

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import DriverAvailabilityCreatePage from "main/pages/Drivers/DriverAvailabilityCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("DriverAvailabilityCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("on submit, makes request to backend, and redirects to /availability", async () => {
+
+        const queryClient = new QueryClient();
+        const availability = {
+            id: 5,
+            driverId: 3,
+            day: "Saturday",
+            startTime: "11:40AM",
+            endTime: "11:59AM",
+            notes: "none",
+        };
+        const noidavailability = {
+            day: "Sunday",
+            driverId: "3",
+            day: "Saturday",
+            startTime: "11:40AM",
+            endTime: "11:59AM",
+            notes: "none",
+        }
+
+        axiosMock.onPost("/api/driverAvailability/new").reply(202, availability);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+
+        const driverIdInput = screen.getByLabelText("driverId")
+        await waitFor(() => {
+            expect(driverIdInput).toBeInTheDocument();
+        });
+
+        const dayInput = screen.getByLabelText("day");
+        expect(dayInput).toBeInTheDocument();
+
+        const startTimeInput = screen.getByLabelText("startTime");
+        expect(startTimeInput).toBeInTheDocument();
+
+        const endTimeInput = screen.getByLabelText("endTime");
+        expect(endTimeInput).toBeInTheDocument();
+
+        const notesInput = screen.getByLabelText("notes");
+        expect(notesInput).toBeInTheDocument();
+
+        // Simulating filling out the form
+        fireEvent.change(dayInput, { target: { value: availability.day } });
+        fireEvent.change(startTimeInput, { target: { value: availability.startTime } });
+        fireEvent.change(endTimeInput, { target: { value: availability.endTime } });
+        fireEvent.change(driverIdInput, { target: { value: String(availability.driverId) } });
+        fireEvent.change(notesInput, { target: { value: String(availability.notes) } });
+
+        const createButton = screen.getByRole('button', { name: /Create/ });
+
+        fireEvent.click(createButton);
+
+        // Wait for the axios call to be made
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        // Asserting that the post request was made with correct parameters
+        expect(axiosMock.history.post[0].params).toEqual(noidavailability);
+
+        // Assert that the toast and navigate functions were called with expected values
+        expect(mockToast).toBeCalledWith(`New Driver Availability Created - id: ${availability.id}`);
+        expect(mockNavigate).toBeCalledWith({ "to": "/availability/" });
+
+    });
+});
+

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -64,7 +64,6 @@ describe("DriverAvailabilityCreatePage tests", () => {
             notes: "none",
         };
         const noidavailability = {
-            day: "Sunday",
             driverId: "3",
             day: "Saturday",
             startTime: "11:40AM",

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityEditPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityEditPage.test.js
@@ -1,0 +1,188 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import DriverAvailabilityEditPage from "main/pages/Drivers/DriverAvailabilityEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("DriverAvailabilityEditPage tests", () => {
+
+    describe("when the backend doesn't return a availability", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/driverAvailability/id", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            const {queryByTestId, findByText} = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DriverAvailabilityEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await findByText("Edit Driver Availability");
+            expect(queryByTestId("day")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/driverAvailability/id", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                driverId: 2,
+                day: "Tuesday",
+                startTime: "05:00PM",
+                endTime: "07:30PM",
+                notes: "none"
+            });
+            axiosMock.onPut('/api/driverAvailability').reply(200, {
+                id: 17,
+                driverId: 1,
+                day: "Monday",
+                startTime: "03:30PM",
+                endTime: "04:30PM",
+                notes: "important"
+            });
+              
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DriverAvailabilityEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DriverAvailabilityEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("DriverAvailabilityForm-day");
+
+            const dayField = getByTestId("DriverAvailabilityForm-day");
+            const startTimeField = getByTestId("DriverAvailabilityForm-startTime");
+            const endTimeField = getByTestId("DriverAvailabilityForm-endTime");
+            const driverIdField = getByTestId("DriverAvailabilityForm-driverId");
+            const notesField = getByTestId("DriverAvailabilityForm-notes");
+
+            expect(dayField).toHaveValue("Tuesday");
+            expect(startTimeField).toHaveValue("05:00PM");
+            expect(endTimeField).toHaveValue("07:30PM");
+            expect(driverIdField).toHaveValue("2");
+            expect(notesField).toHaveValue("none");
+        });
+
+        test("Changes when you click Update", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DriverAvailabilityEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        
+            await findByTestId("DriverAvailabilityForm-day");
+        
+            const dayField = getByTestId("DriverAvailabilityForm-day");
+            const startTimeField = getByTestId("DriverAvailabilityForm-startTime");
+            const endTimeField = getByTestId("DriverAvailabilityForm-endTime");
+            const driverIdField = getByTestId("DriverAvailabilityForm-driverId");
+            const notesField = getByTestId("DriverAvailabilityForm-notes");
+
+            expect(dayField).toHaveValue("Tuesday");
+            expect(startTimeField).toHaveValue("05:00PM");
+            expect(endTimeField).toHaveValue("07:30PM");
+            expect(driverIdField).toHaveValue("2");
+            expect(notesField).toHaveValue("none");
+            
+            const updateButton = screen.getByRole('button', { name: /Update/ });
+            expect(updateButton).toBeInTheDocument();
+        
+            fireEvent.change(dayField, { target: { value: 'Monday' } });
+            fireEvent.change(startTimeField, { target: { value: '03:30PM' } });
+            fireEvent.change(endTimeField, { target: { value: "04:30PM" } });
+            fireEvent.change(driverIdField, { target: { value: 1 } });
+            fireEvent.change(notesField, { target: { value: "important" } });
+        
+            fireEvent.click(updateButton);
+
+            await waitFor(() => expect(mockToast).toHaveBeenCalled());
+            expect(mockToast).toBeCalledWith("DriverAvailability Updated - id: 17");
+            expect(mockNavigate).toBeCalledWith({ "to": "/availability" });
+            
+            // Asserting the axios PUT call
+            
+            expect(axiosMock.history.put.length).toBe(1);
+
+
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                driverId: "1",
+                day: "Monday",
+                startTime: "03:30PM",
+                endTime: "04:30PM",
+                notes: "important"
+            })); // posted object
+        });
+        
+
+    });
+});

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -1,0 +1,203 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import DriverAvailabilityIndexPage from "main/pages/Drivers/DriverAvailabilityIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { driverAvailabilityFixtures } from "fixtures/driverAvailabilityFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("DriverAvailabilityIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "DriverAvailabilityTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupDriverUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.driverOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+
+    const queryClient = new QueryClient();
+
+
+    test("fetches driverAvailabilities using the correct GET method", async () => {
+        setupAdminUser();
+        axiosMock.onGet("/api/driverAvailability").reply(config => {
+            if (config.method === "get") {  // Ensures the method is GET
+                return [200, driverAvailabilityFixtures.threeAvailability];
+            }
+            return [405, { error: "Method not allowed" }]; // Return a 405 error if the method is not GET
+        });
+    
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    
+        // Check that the DriverAvailabilitys were fetched and displayed
+        await waitFor(() => { 
+            expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+        });
+        
+        // If the method was not GET, the test should throw an error
+        // You could either verify that no error toast is displayed or verify that the DriverAvailabilitys are displayed
+        expect(mockToast).not.toBeCalledWith("Method not allowed");
+    });
+
+    test("fetches DriverAvailabilitys using the GET method", async () => {
+        setupAdminUser();
+    
+        // This variable will help us verify that the correct method was used.
+        let wasGetMethodUsed = false;
+    
+        axiosMock.onAny("/api/driverAvailability").reply(config => {
+            if (config.method === "get") {  
+                wasGetMethodUsed = true; 
+                return [200, driverAvailabilityFixtures.threeAvailability];
+            }
+            // If any other method is used, return an error
+            return [405, { error: "Method not allowed" }];
+        });
+    
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    
+        // Check that the DriverAvailabilitys were fetched and displayed
+        await waitFor(() => { 
+            expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+        });
+        
+        // Check if the correct GET method was used.
+        expect(wasGetMethodUsed).toBeTruthy();
+    
+        // Ensure that no error toast with "Method not allowed" is shown, further validating that GET was used.
+        expect(mockToast).not.toBeCalledWith("Method not allowed");
+    });
+
+    test("Renders with Create Button for driver user", async () => {
+        setupDriverUser();
+        axiosMock.onGet("/api/driverAvailability").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/Create Driver Availability/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Driver Availability/);
+        expect(button).toHaveAttribute("href", "/availability/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    
+    test("renders three DriverAvailabilitys correctly for regular user", async () => {
+        setupDriverUser();
+        axiosMock.onGet("/api/driverAvailability").reply(200, driverAvailabilityFixtures.threeAvailability);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-startTime`)).toHaveTextContent("09:00AM");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-endTime`)).toHaveTextContent("12:00PM");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-notes`)).toHaveTextContent("has class from 8-9am");
+
+
+        const createDriverAvailabilityButton = screen.queryByText("Create Driver Availability");
+        expect(createDriverAvailabilityButton).toBeInTheDocument();
+
+        const day = screen.getByText("Monday");
+        expect(day).toBeInTheDocument();
+
+        // const description = screen.getByText("Burrito joint, and iconic Isla Vista location");
+        // expect(description).toBeInTheDocument();
+
+        // for drivers users all buttons should be visible
+        expect(screen.queryByTestId("DriverAvailabilityTable-cell-row-0-col-Delete-button")).toBeInTheDocument();
+        expect(screen.queryByTestId("DriverAvailabilityTable-cell-row-0-col-Edit-button")).toBeInTheDocument();
+    });
+
+
+
+    test("what happens when you click delete, driver", async () => {
+        setupDriverUser();
+
+        axiosMock.onGet("/api/driverAvailability").reply(200, driverAvailabilityFixtures.threeAvailability);
+        axiosMock.onDelete("/api/driverAvailability").reply(200, "DriverAvailability with id 1 was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverAvailabilityIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("DriverAvailability with id 1 was deleted") });
+
+        await waitFor(() => { expect(axiosMock.history.delete.length).toBe(1); });
+        expect(axiosMock.history.delete[0].url).toBe("/api/driverAvailability");
+        expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    });
+
+});

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -25,13 +25,6 @@ describe("DriverAvailabilityIndexPage tests", () => {
 
     const testId = "DriverAvailabilityTable";
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
-
     const setupAdminUser = () => {
         axiosMock.reset();
         axiosMock.resetHistory();


### PR DESCRIPTION
Make sure to toggle on yourself as a driver when testing!
Also make sure when you create availabilities they use your driverId if you want to see them!

In this PR I make the create, edit, and index pages for Driver Availability. These are contained under the navbar and are stored in the Driver folder like the previous Table and Form PRs. Endpoint for index is /availability, endpoint for create is /availability/create, and endpoint for edit is /availability/edit. Make sure that you switch to a non admin user until the PR for admin pages is up. 

Dev environment: https://gauchoride-jamespflaging-dev.dokku-13.cs.ucsb.edu

<img width="1402" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/91391111/f5744e31-a21d-4e86-94b8-d5db876af5bd">

<img width="1434" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/91391111/25b88f0a-cd7b-4104-b548-adc5cee09979">

<img width="205" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-1/assets/91391111/cd787c09-d448-4c43-8e71-2770c020f6e8">


## Acceptance Criteria: Driver Perspective

- [x] Any driver (ROLE_DRIVER) should be able to see a menu option `Availability` under `Shifts` on the navbar.
- [x] When clicked it takes the user to a table that shows the availability that the driver has previously submitted.
- [x] The user can click a button at the top of the table that goes to `/availability/create` where they can submit their availability for a specific day of the week.
- [x] The user can click "edit" in order to edit a previously submitted availability.

Closes #14 